### PR TITLE
fix: make sure the folder exists before generating pnpm-sync.json

### DIFF
--- a/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
+++ b/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
@@ -60,9 +60,9 @@ export type IVersionSpecifier = string | {
 };
 
 // @beta
-export function pnpmSyncCopyAsync({ pnpmSyncJsonPath, getPackageIncludedFiles, forEachAsyncWithConcurrency, ensureFolder, }: IPnpmSyncCopyOptions): Promise<void>;
+export function pnpmSyncCopyAsync({ pnpmSyncJsonPath, getPackageIncludedFiles, forEachAsyncWithConcurrency, ensureFolder }: IPnpmSyncCopyOptions): Promise<void>;
 
 // @beta
-export function pnpmSyncPrepareAsync({ lockfilePath, storePath, readPnpmLockfile, }: IPnpmSyncPrepareOptions): Promise<void>;
+export function pnpmSyncPrepareAsync({ lockfilePath, storePath, readPnpmLockfile }: IPnpmSyncPrepareOptions): Promise<void>;
 
 ```

--- a/packages/pnpm-sync-lib/package.json
+++ b/packages/pnpm-sync-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync-lib",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "API library for integrating \"pnpm-sync\" with your toolchain",
   "repository": {
     "type": "git",

--- a/packages/pnpm-sync-lib/src/pnpmSyncCopy.ts
+++ b/packages/pnpm-sync-lib/src/pnpmSyncCopy.ts
@@ -67,7 +67,7 @@ export async function pnpmSyncCopyAsync({
   //clear the destination folder first
   for (const targetFolder of targetFolders) {
     const destinationPath = path.resolve(pnpmSyncJsonPath, targetFolder.folderPath);
-    await fs.promises.rm(destinationPath, { recursive: true });
+    await fs.promises.rm(destinationPath, { recursive: true, force: true });
   }
 
   await forEachAsyncWithConcurrency(

--- a/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
+++ b/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
@@ -84,6 +84,11 @@ export async function pnpmSyncPrepareAsync({
       continue;
     }
 
+    // make sure the node_modules folder exists
+    if (!fs.existsSync(`${projectFolder}/node_modules`)) {
+      continue;
+    }
+
     const pnpmSyncJsonPath = `${projectFolder}/node_modules/.pnpm-sync.json`;
 
     let pnpmSyncJsonFile: IPnpmSyncJson = {

--- a/packages/pnpm-sync/package.json
+++ b/packages/pnpm-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Recopy injected dependencies whenever a project is rebuilt in your PNPM workspace",
   "keywords": [
     "rush",


### PR DESCRIPTION
### Problem
The PNPM (pnpm@8.10.2) does not validate the `dependenciesMeta` settings in the `package.json`. 
So, let's say, a user set `dependenciesMeta` in the `package.json` like below
There a typo, the `button1111` is not validated. However, PNPM still put this wrong package name to `pnpm-lock.yaml` file, and there no any warnings or errors.

This will cause problem in pnpm-sync, since we are depending on the `pnpm-lock.yaml` to analyze the injected dependencies. 

```
{
  "name": "form",
  "dependencies": {
    "button": "workspace:1.0.0",
    "react": "17"
  },
  "dependenciesMeta": {
    "button1111": {
      "injected": true
    }
  }
}
```
### Solution
Add a `fs.existsSync ` check when we are generating the `pnpm-sync.json` file, in case when users make typos in the `dependenciesMeta`, it won't break `pnpm-sync` tool
