### PR TITLE
feat: provide a API for users to process log message in pnpm-sync-lib

### DIFF
--- a/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
+++ b/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
@@ -100,17 +100,17 @@ export type IVersionSpecifier = string | {
 // @beta (undocumented)
 export enum LogMessageIdentifier {
     // (undocumented)
-    COPY_FINISHING = "Finishing pnpm-sync copy",
+    COPY_FINISHING = "copy-finishing",
     // (undocumented)
-    COPY_PROCESSING = "Processing pnpm-sync copy",
+    COPY_PROCESSING = "copy-processing",
     // (undocumented)
-    COPY_STARTING = "Starting pnpm-sync copy",
+    COPY_STARTING = "copy-starting",
     // (undocumented)
-    PREPARE_FINISHING = "Finishing pnpm-sync prepare",
+    PREPARE_FINISHING = "prepare-finishing",
     // (undocumented)
-    PREPARE_PROCESSING = "Processing pnpm-sync prepare",
+    PREPARE_PROCESSING = "prepare-processing",
     // (undocumented)
-    PREPARE_STARTING = "Starting pnpm-sync prepare"
+    PREPARE_STARTING = "prepare-starting"
 }
 
 // @beta (undocumented)

--- a/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
+++ b/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
@@ -29,6 +29,18 @@ export interface ILockfileImporter {
 }
 
 // @beta (undocumented)
+export enum ILogMessageKind {
+    // (undocumented)
+    ERROR = "error",
+    // (undocumented)
+    INFO = "info",
+    // (undocumented)
+    VERBOSE = "verbose",
+    // (undocumented)
+    WARNING = "warning"
+}
+
+// @beta (undocumented)
 export interface IPnpmSyncCopyOptions {
     // (undocumented)
     ensureFolder: (folderPath: string) => Promise<void>;
@@ -39,6 +51,11 @@ export interface IPnpmSyncCopyOptions {
     // (undocumented)
     getPackageIncludedFiles: (packagePath: string) => Promise<string[]>;
     // (undocumented)
+    logMessageCallback: (message: string, messageKind: ILogMessageKind, details?: {
+        fileCount: number;
+        executionTimeInMs: string;
+    }) => void;
+    // (undocumented)
     pnpmSyncJsonPath?: string;
 }
 
@@ -46,6 +63,12 @@ export interface IPnpmSyncCopyOptions {
 export interface IPnpmSyncPrepareOptions {
     // (undocumented)
     lockfilePath: string;
+    // (undocumented)
+    logMessageCallback: (message: string, messageKind: ILogMessageKind, details?: {
+        lockfilePath: string;
+        dotPnpmFolderPath: string;
+        executionTimeInMs: string;
+    }) => void;
     // (undocumented)
     readPnpmLockfile: (lockfilePath: string, options: {
         ignoreIncompatible: boolean;
@@ -60,9 +83,9 @@ export type IVersionSpecifier = string | {
 };
 
 // @beta
-export function pnpmSyncCopyAsync({ pnpmSyncJsonPath, getPackageIncludedFiles, forEachAsyncWithConcurrency, ensureFolder }: IPnpmSyncCopyOptions): Promise<void>;
+export function pnpmSyncCopyAsync({ pnpmSyncJsonPath, getPackageIncludedFiles, forEachAsyncWithConcurrency, ensureFolder, logMessageCallback }: IPnpmSyncCopyOptions): Promise<void>;
 
 // @beta
-export function pnpmSyncPrepareAsync({ lockfilePath, storePath, readPnpmLockfile }: IPnpmSyncPrepareOptions): Promise<void>;
+export function pnpmSyncPrepareAsync({ lockfilePath, storePath, readPnpmLockfile, logMessageCallback }: IPnpmSyncPrepareOptions): Promise<void>;
 
 ```

--- a/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
+++ b/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
@@ -29,15 +29,37 @@ export interface ILockfileImporter {
 }
 
 // @beta (undocumented)
-export enum ILogMessageKind {
+export interface ILogMessageCallbackOptions {
     // (undocumented)
-    ERROR = "error",
+    details: {
+        messageIdentifier: LogMessageIdentifier.PREPARE_STARTING;
+        lockfilePath: string;
+        dotPnpmFolderPath: string;
+    } | {
+        messageIdentifier: LogMessageIdentifier.PREPARE_PROCESSING;
+        lockfilePath: string;
+        dotPnpmFolderPath: string;
+    } | {
+        messageIdentifier: LogMessageIdentifier.PREPARE_FINISHING;
+        lockfilePath: string;
+        dotPnpmFolderPath: string;
+        executionTimeInMs: string;
+    } | {
+        messageIdentifier: LogMessageIdentifier.COPY_STARTING;
+        pnpmSyncJsonPath: string;
+    } | {
+        messageIdentifier: LogMessageIdentifier.COPY_PROCESSING;
+        pnpmSyncJsonPath: string;
+    } | {
+        messageIdentifier: LogMessageIdentifier.COPY_FINISHING;
+        pnpmSyncJsonPath: string;
+        fileCount: number;
+        executionTimeInMs: string;
+    };
     // (undocumented)
-    INFO = "info",
+    message: string;
     // (undocumented)
-    VERBOSE = "verbose",
-    // (undocumented)
-    WARNING = "warning"
+    messageKind: LogMessageKind;
 }
 
 // @beta (undocumented)
@@ -51,10 +73,7 @@ export interface IPnpmSyncCopyOptions {
     // (undocumented)
     getPackageIncludedFiles: (packagePath: string) => Promise<string[]>;
     // (undocumented)
-    logMessageCallback: (message: string, messageKind: ILogMessageKind, details?: {
-        fileCount: number;
-        executionTimeInMs: string;
-    }) => void;
+    logMessageCallback: (options: ILogMessageCallbackOptions) => void;
     // (undocumented)
     pnpmSyncJsonPath?: string;
 }
@@ -64,11 +83,7 @@ export interface IPnpmSyncPrepareOptions {
     // (undocumented)
     lockfilePath: string;
     // (undocumented)
-    logMessageCallback: (message: string, messageKind: ILogMessageKind, details?: {
-        lockfilePath: string;
-        dotPnpmFolderPath: string;
-        executionTimeInMs: string;
-    }) => void;
+    logMessageCallback: (options: ILogMessageCallbackOptions) => void;
     // (undocumented)
     readPnpmLockfile: (lockfilePath: string, options: {
         ignoreIncompatible: boolean;
@@ -81,6 +96,34 @@ export interface IPnpmSyncPrepareOptions {
 export type IVersionSpecifier = string | {
     version: string;
 };
+
+// @beta (undocumented)
+export enum LogMessageIdentifier {
+    // (undocumented)
+    COPY_FINISHING = "Finishing pnpm-sync copy",
+    // (undocumented)
+    COPY_PROCESSING = "Processing pnpm-sync copy",
+    // (undocumented)
+    COPY_STARTING = "Starting pnpm-sync copy",
+    // (undocumented)
+    PREPARE_FINISHING = "Finishing pnpm-sync prepare",
+    // (undocumented)
+    PREPARE_PROCESSING = "Processing pnpm-sync prepare",
+    // (undocumented)
+    PREPARE_STARTING = "Starting pnpm-sync prepare"
+}
+
+// @beta (undocumented)
+export enum LogMessageKind {
+    // (undocumented)
+    ERROR = "error",
+    // (undocumented)
+    INFO = "info",
+    // (undocumented)
+    VERBOSE = "verbose",
+    // (undocumented)
+    WARNING = "warning"
+}
 
 // @beta
 export function pnpmSyncCopyAsync({ pnpmSyncJsonPath, getPackageIncludedFiles, forEachAsyncWithConcurrency, ensureFolder, logMessageCallback }: IPnpmSyncCopyOptions): Promise<void>;

--- a/packages/pnpm-sync-lib/src/index.ts
+++ b/packages/pnpm-sync-lib/src/index.ts
@@ -7,5 +7,11 @@
 
 export { pnpmSyncCopyAsync, type IPnpmSyncCopyOptions } from './pnpmSyncCopy';
 export { pnpmSyncPrepareAsync, type IPnpmSyncPrepareOptions } from './pnpmSyncPrepare';
-export { ILogMessageKind } from './interfaces';
-export type { ILockfile, ILockfileImporter, IVersionSpecifier, IDependencyMeta } from './interfaces';
+export { LogMessageIdentifier, LogMessageKind } from './interfaces';
+export type {
+  ILockfile,
+  ILockfileImporter,
+  IVersionSpecifier,
+  IDependencyMeta,
+  ILogMessageCallbackOptions
+} from './interfaces';

--- a/packages/pnpm-sync-lib/src/index.ts
+++ b/packages/pnpm-sync-lib/src/index.ts
@@ -7,4 +7,5 @@
 
 export { pnpmSyncCopyAsync, type IPnpmSyncCopyOptions } from './pnpmSyncCopy';
 export { pnpmSyncPrepareAsync, type IPnpmSyncPrepareOptions } from './pnpmSyncPrepare';
+export { ILogMessageKind } from './interfaces';
 export type { ILockfile, ILockfileImporter, IVersionSpecifier, IDependencyMeta } from './interfaces';

--- a/packages/pnpm-sync-lib/src/interfaces.ts
+++ b/packages/pnpm-sync-lib/src/interfaces.ts
@@ -18,11 +18,62 @@ export interface ITargetFolder {
 /**
  * @beta
  */
-export enum ILogMessageKind {
+export enum LogMessageKind {
   INFO = 'info',
   WARNING = 'warning',
   ERROR = 'error',
   VERBOSE = 'verbose'
+}
+
+/**
+ * @beta
+ */
+export enum LogMessageIdentifier {
+  PREPARE_STARTING = 'Starting pnpm-sync prepare',
+  PREPARE_PROCESSING = 'Processing pnpm-sync prepare',
+  PREPARE_FINISHING = 'Finishing pnpm-sync prepare',
+  COPY_STARTING = 'Starting pnpm-sync copy',
+  COPY_PROCESSING = 'Processing pnpm-sync copy',
+  COPY_FINISHING = 'Finishing pnpm-sync copy'
+}
+
+/**
+ * @beta
+ */
+export interface ILogMessageCallbackOptions {
+  message: string;
+  messageKind: LogMessageKind;
+  details:
+    | {
+        messageIdentifier: LogMessageIdentifier.PREPARE_STARTING;
+        lockfilePath: string;
+        dotPnpmFolderPath: string;
+      }
+    | {
+        messageIdentifier: LogMessageIdentifier.PREPARE_PROCESSING;
+        lockfilePath: string;
+        dotPnpmFolderPath: string;
+      }
+    | {
+        messageIdentifier: LogMessageIdentifier.PREPARE_FINISHING;
+        lockfilePath: string;
+        dotPnpmFolderPath: string;
+        executionTimeInMs: string;
+      }
+    | {
+        messageIdentifier: LogMessageIdentifier.COPY_STARTING;
+        pnpmSyncJsonPath: string;
+      }
+    | {
+        messageIdentifier: LogMessageIdentifier.COPY_PROCESSING;
+        pnpmSyncJsonPath: string;
+      }
+    | {
+        messageIdentifier: LogMessageIdentifier.COPY_FINISHING;
+        pnpmSyncJsonPath: string;
+        fileCount: number;
+        executionTimeInMs: string;
+      };
 }
 
 /**

--- a/packages/pnpm-sync-lib/src/interfaces.ts
+++ b/packages/pnpm-sync-lib/src/interfaces.ts
@@ -18,6 +18,16 @@ export interface ITargetFolder {
 /**
  * @beta
  */
+export enum ILogMessageKind {
+  INFO = 'info',
+  WARNING = 'warning',
+  ERROR = 'error',
+  VERBOSE = 'verbose'
+}
+
+/**
+ * @beta
+ */
 export interface IDependencyMeta {
   injected?: boolean;
 }

--- a/packages/pnpm-sync-lib/src/interfaces.ts
+++ b/packages/pnpm-sync-lib/src/interfaces.ts
@@ -29,12 +29,12 @@ export enum LogMessageKind {
  * @beta
  */
 export enum LogMessageIdentifier {
-  PREPARE_STARTING = 'Starting pnpm-sync prepare',
-  PREPARE_PROCESSING = 'Processing pnpm-sync prepare',
-  PREPARE_FINISHING = 'Finishing pnpm-sync prepare',
-  COPY_STARTING = 'Starting pnpm-sync copy',
-  COPY_PROCESSING = 'Processing pnpm-sync copy',
-  COPY_FINISHING = 'Finishing pnpm-sync copy'
+  PREPARE_STARTING = 'prepare-starting',
+  PREPARE_PROCESSING = 'prepare-processing',
+  PREPARE_FINISHING = 'prepare-finishing',
+  COPY_STARTING = 'copy-starting',
+  COPY_PROCESSING = 'copy-processing',
+  COPY_FINISHING = 'copy-finishing'
 }
 
 /**

--- a/packages/pnpm-sync/src/start.ts
+++ b/packages/pnpm-sync/src/start.ts
@@ -1,5 +1,10 @@
 import { Command } from 'commander';
-import { pnpmSyncCopyAsync, pnpmSyncPrepareAsync, ILogMessageKind } from 'pnpm-sync-lib';
+import {
+  pnpmSyncCopyAsync,
+  pnpmSyncPrepareAsync,
+  LogMessageKind,
+  type ILogMessageCallbackOptions
+} from 'pnpm-sync-lib';
 import { FileSystem, Async } from '@rushstack/node-core-library';
 import { PackageExtractor } from '@rushstack/package-extractor';
 import { readWantedLockfile, Lockfile } from '@pnpm/lockfile-file';
@@ -17,12 +22,13 @@ program
         getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
         forEachAsyncWithConcurrency: Async.forEachAsync,
         ensureFolder: FileSystem.ensureFolderAsync,
-        logMessageCallback: (message: string, messageType: ILogMessageKind) => {
-          switch (messageType) {
-            case ILogMessageKind.ERROR:
+        logMessageCallback: (options: ILogMessageCallbackOptions) => {
+          const { message, messageKind } = options;
+          switch (messageKind) {
+            case LogMessageKind.ERROR:
               console.error(message);
               break;
-            case ILogMessageKind.WARNING:
+            case LogMessageKind.WARNING:
               console.warn(message);
               break;
             default:
@@ -60,12 +66,13 @@ program
             return lockfile;
           }
         },
-        logMessageCallback: (message: string, messageType: ILogMessageKind) => {
-          switch (messageType) {
-            case ILogMessageKind.ERROR:
+        logMessageCallback: (options: ILogMessageCallbackOptions) => {
+          const { message, messageKind } = options;
+          switch (messageKind) {
+            case LogMessageKind.ERROR:
               console.error(message);
               break;
-            case ILogMessageKind.WARNING:
+            case LogMessageKind.WARNING:
               console.warn(message);
               break;
             default:

--- a/packages/pnpm-sync/src/start.ts
+++ b/packages/pnpm-sync/src/start.ts
@@ -1,10 +1,5 @@
 import { Command } from 'commander';
-import {
-  pnpmSyncCopyAsync,
-  pnpmSyncPrepareAsync,
-  LogMessageKind,
-  type ILogMessageCallbackOptions
-} from 'pnpm-sync-lib';
+import { pnpmSyncCopyAsync, pnpmSyncPrepareAsync, type ILogMessageCallbackOptions } from 'pnpm-sync-lib';
 import { FileSystem, Async } from '@rushstack/node-core-library';
 import { PackageExtractor } from '@rushstack/package-extractor';
 import { readWantedLockfile, Lockfile } from '@pnpm/lockfile-file';
@@ -25,10 +20,10 @@ program
         logMessageCallback: (options: ILogMessageCallbackOptions) => {
           const { message, messageKind } = options;
           switch (messageKind) {
-            case LogMessageKind.ERROR:
+            case 'error':
               console.error(message);
               break;
-            case LogMessageKind.WARNING:
+            case 'warning':
               console.warn(message);
               break;
             default:
@@ -69,10 +64,10 @@ program
         logMessageCallback: (options: ILogMessageCallbackOptions) => {
           const { message, messageKind } = options;
           switch (messageKind) {
-            case LogMessageKind.ERROR:
+            case 'error':
               console.error(message);
               break;
-            case LogMessageKind.WARNING:
+            case 'warning':
               console.warn(message);
               break;
             default:

--- a/packages/pnpm-sync/src/start.ts
+++ b/packages/pnpm-sync/src/start.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { pnpmSyncCopyAsync, pnpmSyncPrepareAsync } from 'pnpm-sync-lib';
+import { pnpmSyncCopyAsync, pnpmSyncPrepareAsync, ILogMessageKind } from 'pnpm-sync-lib';
 import { FileSystem, Async } from '@rushstack/node-core-library';
 import { PackageExtractor } from '@rushstack/package-extractor';
 import { readWantedLockfile, Lockfile } from '@pnpm/lockfile-file';
@@ -16,7 +16,20 @@ program
       await pnpmSyncCopyAsync({
         getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
         forEachAsyncWithConcurrency: Async.forEachAsync,
-        ensureFolder: FileSystem.ensureFolderAsync
+        ensureFolder: FileSystem.ensureFolderAsync,
+        logMessageCallback: (message: string, messageType: ILogMessageKind) => {
+          switch (messageType) {
+            case ILogMessageKind.ERROR:
+              console.error(message);
+              break;
+            case ILogMessageKind.WARNING:
+              console.warn(message);
+              break;
+            default:
+              console.log(message);
+              break;
+          }
+        }
       })
   );
 
@@ -45,6 +58,19 @@ program
             return undefined;
           } else {
             return lockfile;
+          }
+        },
+        logMessageCallback: (message: string, messageType: ILogMessageKind) => {
+          switch (messageType) {
+            case ILogMessageKind.ERROR:
+              console.error(message);
+              break;
+            case ILogMessageKind.WARNING:
+              console.warn(message);
+              break;
+            default:
+              console.log(message);
+              break;
           }
         }
       });


### PR DESCRIPTION
### Summary
This PR is to address https://github.com/tiktok/pnpm-sync/issues/14

Currently, the `pnpm-sync-lib` will console.log messages directly.

This brings inconvenience for users who want to customize the log message when integrating to their own Monorepo management tools.

### Details
1. Refactor API interfaces for `pnpmSyncCopyAsync` and `pnpmSyncPrepareAsync` in `pnpm-sync-lib`, adds a `logMessageCallback` for users to customize the log behavior 
2. Refactor `pnpm-sync` to use new API interfaces
