### PR TITLE
fix: add version check for lockfile

### DIFF
--- a/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
+++ b/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
@@ -14,6 +14,8 @@ export interface IDependencyMeta {
 export interface ILockfile {
     // (undocumented)
     importers: Record<string, ILockfileImporter>;
+    // (undocumented)
+    lockfileVersion: number | string;
 }
 
 // @beta (undocumented)

--- a/packages/pnpm-sync-lib/package.json
+++ b/packages/pnpm-sync-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync-lib",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "API library for integrating \"pnpm-sync\" with your toolchain",
   "repository": {
     "type": "git",

--- a/packages/pnpm-sync-lib/src/interfaces.ts
+++ b/packages/pnpm-sync-lib/src/interfaces.ts
@@ -108,5 +108,6 @@ export interface ILockfileImporter {
  * @beta
  */
 export interface ILockfile {
+  lockfileVersion: number | string;
   importers: Record<string, ILockfileImporter>;
 }

--- a/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
+++ b/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
@@ -58,16 +58,22 @@ export async function pnpmSyncPrepareAsync({
     }
   });
 
-  if (!fs.existsSync(lockfilePath)) {
-    throw Error('The input pnpm-lock.yaml path is not correct!');
+  if (!fs.existsSync(lockfilePath) || !fs.existsSync(storePath)) {
+    throw Error('The input pnpm-lock.yaml path or the input .pnpm folder path is not correct!');
   }
 
   const startTime = hrtime.bigint();
 
   // read the pnpm-lock.yaml
-  const pnpmLockfile = await readPnpmLockfile(lockfilePath, {
+  const pnpmLockfile: ILockfile | undefined = await readPnpmLockfile(lockfilePath, {
     ignoreIncompatible: true
   });
+
+  // currently, only support lockfileVersion 6.x, which is pnpm v8
+  const lockfileVersion: string | undefined = pnpmLockfile?.lockfileVersion.toString();
+  if (!lockfileVersion || !lockfileVersion.startsWith('6.')) {
+    throw Error('The input pnpm-lock.yaml version is not supported! Only support lockfile version 6.x');
+  }
 
   // find injected dependency and all its available versions
   const injectedDependencyToVersion: Map<string, Set<string>> = getInjectedDependencyToVersion(pnpmLockfile);

--- a/packages/pnpm-sync/package.json
+++ b/packages/pnpm-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Recopy injected dependencies whenever a project is rebuilt in your PNPM workspace",
   "keywords": [
     "rush",


### PR DESCRIPTION
We only support pnpm-lock.yaml version 6.x, which corresponding to pnpm 8.x