### PR TITLE
feat: support transitive injected dependency

### DIFF
--- a/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
+++ b/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
@@ -16,6 +16,8 @@ export interface ILockfile {
     importers: Record<string, ILockfileImporter>;
     // (undocumented)
     lockfileVersion: number | string;
+    // (undocumented)
+    packages: Record<string, ILockfilePackage>;
 }
 
 // @beta (undocumented)
@@ -27,6 +29,12 @@ export interface ILockfileImporter {
     // (undocumented)
     devDependencies?: Record<string, IVersionSpecifier>;
     // (undocumented)
+    optionalDependencies?: Record<string, IVersionSpecifier>;
+}
+
+// @beta (undocumented)
+export interface ILockfilePackage {
+    dependencies?: Record<string, IVersionSpecifier>;
     optionalDependencies?: Record<string, IVersionSpecifier>;
 }
 
@@ -83,6 +91,8 @@ export interface IPnpmSyncCopyOptions {
 // @beta (undocumented)
 export interface IPnpmSyncPrepareOptions {
     // (undocumented)
+    ensureFolder: (folderPath: string) => Promise<void>;
+    // (undocumented)
     lockfilePath: string;
     // (undocumented)
     logMessageCallback: (options: ILogMessageCallbackOptions) => void;
@@ -131,6 +141,6 @@ export enum LogMessageKind {
 export function pnpmSyncCopyAsync({ pnpmSyncJsonPath, getPackageIncludedFiles, forEachAsyncWithConcurrency, ensureFolder, logMessageCallback }: IPnpmSyncCopyOptions): Promise<void>;
 
 // @beta
-export function pnpmSyncPrepareAsync({ lockfilePath, storePath, readPnpmLockfile, logMessageCallback }: IPnpmSyncPrepareOptions): Promise<void>;
+export function pnpmSyncPrepareAsync({ lockfilePath, storePath, ensureFolder, readPnpmLockfile, logMessageCallback }: IPnpmSyncPrepareOptions): Promise<void>;
 
 ```

--- a/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
+++ b/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
@@ -14,7 +14,6 @@ export interface IDependencyMeta {
 export interface ILockfile {
     // (undocumented)
     importers: Record<string, ILockfileImporter>;
-    // (undocumented)
     lockfileVersion: number | string;
     // (undocumented)
     packages: Record<string, ILockfilePackage>;

--- a/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
+++ b/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
@@ -15,11 +15,10 @@ export interface ILockfile {
     // (undocumented)
     importers: Record<string, ILockfileImporter>;
     lockfileVersion: number | string;
-    // (undocumented)
     packages: Record<string, ILockfilePackage>;
 }
 
-// @beta (undocumented)
+// @beta
 export interface ILockfileImporter {
     // (undocumented)
     dependencies?: Record<string, IVersionSpecifier>;
@@ -33,8 +32,8 @@ export interface ILockfileImporter {
 
 // @beta (undocumented)
 export interface ILockfilePackage {
-    dependencies?: Record<string, IVersionSpecifier>;
-    optionalDependencies?: Record<string, IVersionSpecifier>;
+    dependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
 }
 
 // @beta (undocumented)
@@ -105,6 +104,7 @@ export interface IPnpmSyncPrepareOptions {
 
 // @beta (undocumented)
 export type IVersionSpecifier = string | {
+    specifier: string;
     version: string;
 };
 

--- a/packages/pnpm-sync-lib/package.json
+++ b/packages/pnpm-sync-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync-lib",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "API library for integrating \"pnpm-sync\" with your toolchain",
   "repository": {
     "type": "git",

--- a/packages/pnpm-sync-lib/src/index.ts
+++ b/packages/pnpm-sync-lib/src/index.ts
@@ -11,6 +11,7 @@ export { LogMessageIdentifier, LogMessageKind } from './interfaces';
 export type {
   ILockfile,
   ILockfileImporter,
+  ILockfilePackage,
   IVersionSpecifier,
   IDependencyMeta,
   ILogMessageCallbackOptions

--- a/packages/pnpm-sync-lib/src/interfaces.ts
+++ b/packages/pnpm-sync-lib/src/interfaces.ts
@@ -89,10 +89,15 @@ export interface IDependencyMeta {
 export type IVersionSpecifier =
   | string
   | {
+      specifier: string;
       version: string;
     };
 
 /**
+ * Represents the installation plan for a local workspace project.
+ * The `"peerDependencies"` field is not included in this data structure
+ * because PNPM cannot install peer dependency doppelgangers for a local workspace
+ * project (since they would need to be represented as injected dependencies).
  * @beta
  */
 export interface ILockfileImporter {
@@ -107,9 +112,9 @@ export interface ILockfileImporter {
  */
 export interface ILockfilePackage {
   /** The list of dependencies and the resolved version */
-  dependencies?: Record<string, IVersionSpecifier>;
+  dependencies?: Record<string, string>;
   /** The list of optional dependencies and the resolved version */
-  optionalDependencies?: Record<string, IVersionSpecifier>;
+  optionalDependencies?: Record<string, string>;
 }
 
 /**
@@ -125,5 +130,12 @@ export interface ILockfile {
    */
   lockfileVersion: number | string;
   importers: Record<string, ILockfileImporter>;
+  /**
+   * The `packages` section stores the installation plan for external (non-workspace)
+   * packages.  The key is a `node_modules/.pnpm` version path, which in lockfile version 6
+   * encodes the installed package name, package version, and any peer dependency qualifiers.
+   *
+   * Example key: `/webpack-filter-warnings-plugin@1.2.1(webpack@4.47.0)`
+   */
   packages: Record<string, ILockfilePackage>;
 }

--- a/packages/pnpm-sync-lib/src/interfaces.ts
+++ b/packages/pnpm-sync-lib/src/interfaces.ts
@@ -103,6 +103,16 @@ export interface ILockfileImporter {
 }
 
 /**
+ * @beta
+ */
+export interface ILockfilePackage {
+  /** The list of dependencies and the resolved version */
+  dependencies?: Record<string, IVersionSpecifier>;
+  /** The list of optional dependencies and the resolved version */
+  optionalDependencies?: Record<string, IVersionSpecifier>;
+}
+
+/**
  * An abstraction of the pnpm lockfile
  *
  * @beta
@@ -110,4 +120,5 @@ export interface ILockfileImporter {
 export interface ILockfile {
   lockfileVersion: number | string;
   importers: Record<string, ILockfileImporter>;
+  packages: Record<string, ILockfilePackage>;
 }

--- a/packages/pnpm-sync-lib/src/interfaces.ts
+++ b/packages/pnpm-sync-lib/src/interfaces.ts
@@ -113,11 +113,16 @@ export interface ILockfilePackage {
 }
 
 /**
- * An abstraction of the pnpm lockfile
+ * This interface represents the data structure that is parsed from `pnpm-lock.yaml`
  *
  * @beta
  */
 export interface ILockfile {
+  /**
+   * The version of the `pnpm-lock.yaml` file format.
+   *
+   * Example: `6.0`
+   */
   lockfileVersion: number | string;
   importers: Record<string, ILockfileImporter>;
   packages: Record<string, ILockfilePackage>;

--- a/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
+++ b/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
@@ -8,7 +8,8 @@ import {
   LogMessageKind,
   LogMessageIdentifier,
   IPnpmSyncJson,
-  IVersionSpecifier
+  IVersionSpecifier,
+  ILockfilePackage
 } from './interfaces';
 
 /**
@@ -17,6 +18,7 @@ import {
 export interface IPnpmSyncPrepareOptions {
   lockfilePath: string;
   storePath: string;
+  ensureFolder: (folderPath: string) => Promise<void>;
   readPnpmLockfile: (
     lockfilePath: string,
     options: { ignoreIncompatible: boolean }
@@ -38,6 +40,7 @@ export interface IPnpmSyncPrepareOptions {
 export async function pnpmSyncPrepareAsync({
   lockfilePath,
   storePath,
+  ensureFolder,
   readPnpmLockfile,
   logMessageCallback
 }: IPnpmSyncPrepareOptions): Promise<void> {
@@ -78,6 +81,9 @@ export async function pnpmSyncPrepareAsync({
   // find injected dependency and all its available versions
   const injectedDependencyToVersion: Map<string, Set<string>> = getInjectedDependencyToVersion(pnpmLockfile);
 
+  // check and process transitive injected dependency
+  processTransitiveInjectedDependency(pnpmLockfile, injectedDependencyToVersion);
+
   // get pnpm-lock.yaml folder path
   const pnpmLockFolder = lockfilePath.slice(0, lockfilePath.length - 'pnpm-lock.yaml'.length);
 
@@ -107,9 +113,14 @@ export async function pnpmSyncPrepareAsync({
       continue;
     }
 
-    // make sure the node_modules folder exists
-    if (!fs.existsSync(`${projectFolder}/node_modules`)) {
-      continue;
+    // make sure the node_modules folder exists, if not, create it
+    // why?
+    // in the transitive injected dependencies case
+    // it is possible that node_modules folder a package is not exist
+    // but we need to generate .pnpm-sync.json for that package
+    const projectNodeModulesFolderPath = `${projectFolder}/node_modules`;
+    if (!fs.existsSync(projectNodeModulesFolderPath)) {
+      await ensureFolder(projectNodeModulesFolderPath);
     }
 
     const pnpmSyncJsonPath = `${projectFolder}/node_modules/.pnpm-sync.json`;
@@ -225,6 +236,62 @@ function processDependencies(
       if (injectedDependencyToVersion.has(dependency)) {
         const specifierToUse: string = typeof specifier === 'string' ? specifier : specifier.version;
         injectedDependencyToVersion.get(dependency)?.add(specifierToUse);
+      }
+    }
+  }
+}
+
+// process all dependencies and devDependencies to find potential transitive injected dependencies
+// and add to injectedDependencyToFilePath map
+function processTransitiveInjectedDependency(
+  pnpmLockfile: ILockfile | undefined,
+  injectedDependencyToVersion: Map<string, Set<string>>
+): void {
+  const potentialTransitiveInjectedDependencyVersionQueue: Array<string> = [];
+  for (const injectedDependencyVersion of [...injectedDependencyToVersion.values()]) {
+    for (const version of [...injectedDependencyVersion]) {
+      potentialTransitiveInjectedDependencyVersionQueue.push(version);
+    }
+  }
+
+  const lockfilePackages: Record<string, ILockfilePackage> | undefined = pnpmLockfile?.packages;
+
+  if (lockfilePackages) {
+    while (potentialTransitiveInjectedDependencyVersionQueue.length > 0) {
+      const transitiveInjectedDependencyVersion: string | undefined =
+        potentialTransitiveInjectedDependencyVersionQueue.shift();
+      if (transitiveInjectedDependencyVersion) {
+        const { dependencies, optionalDependencies } = lockfilePackages[transitiveInjectedDependencyVersion];
+        processInjectedDependencies(
+          dependencies,
+          injectedDependencyToVersion,
+          potentialTransitiveInjectedDependencyVersionQueue
+        );
+        processInjectedDependencies(
+          optionalDependencies,
+          injectedDependencyToVersion,
+          potentialTransitiveInjectedDependencyVersionQueue
+        );
+      }
+    }
+  }
+}
+function processInjectedDependencies(
+  dependencies: Record<string, IVersionSpecifier> | undefined,
+  injectedDependencyToVersion: Map<string, Set<string>>,
+  potentialTransitiveInjectedDependencyVersionQueue: Array<string>
+): void {
+  if (dependencies) {
+    for (const [dependency, specifier] of Object.entries(dependencies)) {
+      const specifierToUse: string = typeof specifier === 'string' ? specifier : specifier.version;
+
+      // if the version is set with file: protocol, then it is a transitive injected dependency
+      if (specifierToUse.startsWith('file:')) {
+        if (!injectedDependencyToVersion.has(dependency)) {
+          injectedDependencyToVersion.set(dependency, new Set());
+        }
+        injectedDependencyToVersion.get(dependency)?.add(specifierToUse);
+        potentialTransitiveInjectedDependencyVersionQueue.push(specifierToUse);
       }
     }
   }

--- a/packages/pnpm-sync/package.json
+++ b/packages/pnpm-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Recopy injected dependencies whenever a project is rebuilt in your PNPM workspace",
   "keywords": [
     "rush",

--- a/packages/pnpm-sync/src/start.ts
+++ b/packages/pnpm-sync/src/start.ts
@@ -65,22 +65,15 @@ program
           if (lockfile === null) {
             return undefined;
           } else {
-            const lockfilePackages: Record<string, ILockfilePackage> = {};
-            for (const packagePath in lockfile.packages) {
-              if (lockfile.packages[packagePath]) {
-                lockfilePackages[packagePath] = {
-                  dependencies: lockfile.packages[packagePath].dependencies,
-                  optionalDependencies: lockfile.packages[packagePath].optionalDependencies
-                };
-              }
-            }
-
+            const lockfilePackages: Record<string, ILockfilePackage> = lockfile.packages as Record<
+              string,
+              ILockfilePackage
+            >;
             const result: ILockfile = {
               lockfileVersion: lockfile.lockfileVersion,
               importers: lockfile.importers,
               packages: lockfilePackages
             };
-
             return result;
           }
         },


### PR DESCRIPTION
## Summary
This PR to support transitive injected dependency situation.
## Details
When we were working on supporting PNPM injected install feature for Rush Subspace, we got a conclusion that if a package gets installed in the injected way then every workspace:* dependency of that package also gets injected. (See more details on [this PR](https://github.com/microsoft/rushstack/pull/4583))
This means, for all dependencies all that dependency chain, we need to generate the `.pnpm-sync.json` for them, to make the installation and build behavior correct.
