### PR TITLE
API improvements to support RushJS integration

### DIFF
--- a/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
+++ b/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
@@ -39,31 +39,7 @@ export interface ILockfilePackage {
 // @beta (undocumented)
 export interface ILogMessageCallbackOptions {
     // (undocumented)
-    details: {
-        messageIdentifier: LogMessageIdentifier.PREPARE_STARTING;
-        lockfilePath: string;
-        dotPnpmFolderPath: string;
-    } | {
-        messageIdentifier: LogMessageIdentifier.PREPARE_PROCESSING;
-        lockfilePath: string;
-        dotPnpmFolderPath: string;
-    } | {
-        messageIdentifier: LogMessageIdentifier.PREPARE_FINISHING;
-        lockfilePath: string;
-        dotPnpmFolderPath: string;
-        executionTimeInMs: string;
-    } | {
-        messageIdentifier: LogMessageIdentifier.COPY_STARTING;
-        pnpmSyncJsonPath: string;
-    } | {
-        messageIdentifier: LogMessageIdentifier.COPY_PROCESSING;
-        pnpmSyncJsonPath: string;
-    } | {
-        messageIdentifier: LogMessageIdentifier.COPY_FINISHING;
-        pnpmSyncJsonPath: string;
-        fileCount: number;
-        executionTimeInMs: string;
-    };
+    details: LogMessageDetails;
     // (undocumented)
     message: string;
     // (undocumented)
@@ -72,34 +48,24 @@ export interface ILogMessageCallbackOptions {
 
 // @beta (undocumented)
 export interface IPnpmSyncCopyOptions {
-    // (undocumented)
     ensureFolder: (folderPath: string) => Promise<void>;
-    // (undocumented)
     forEachAsyncWithConcurrency: <TItem>(iterable: Iterable<TItem>, callback: (item: TItem) => Promise<void>, options: {
         concurrency: number;
     }) => Promise<void>;
-    // (undocumented)
     getPackageIncludedFiles: (packagePath: string) => Promise<string[]>;
-    // (undocumented)
     logMessageCallback: (options: ILogMessageCallbackOptions) => void;
-    // (undocumented)
-    pnpmSyncJsonPath?: string;
+    pnpmSyncJsonPath: string;
 }
 
 // @beta (undocumented)
 export interface IPnpmSyncPrepareOptions {
-    // (undocumented)
+    dotPnpmFolder: string;
     ensureFolder: (folderPath: string) => Promise<void>;
-    // (undocumented)
     lockfilePath: string;
-    // (undocumented)
     logMessageCallback: (options: ILogMessageCallbackOptions) => void;
-    // (undocumented)
     readPnpmLockfile: (lockfilePath: string, options: {
         ignoreIncompatible: boolean;
     }) => Promise<ILockfile | undefined>;
-    // (undocumented)
-    storePath: string;
 }
 
 // @beta (undocumented)
@@ -109,19 +75,59 @@ export type IVersionSpecifier = string | {
 };
 
 // @beta (undocumented)
+export type LogMessageDetails = {
+    messageIdentifier: LogMessageIdentifier.PREPARE_STARTING;
+    lockfilePath: string;
+    dotPnpmFolder: string;
+} | {
+    messageIdentifier: LogMessageIdentifier.PREPARE_ERROR_UNSUPPORTED_FORMAT;
+    lockfilePath: string;
+    lockfileVersion: string | undefined;
+} | {
+    messageIdentifier: LogMessageIdentifier.PREPARE_PROCESSING;
+    lockfilePath: string;
+    dotPnpmFolderPath: string;
+} | {
+    messageIdentifier: LogMessageIdentifier.PREPARE_WRITING_FILE;
+    pnpmSyncJsonPath: string;
+    projectFolder: string;
+} | {
+    messageIdentifier: LogMessageIdentifier.PREPARE_FINISHING;
+    lockfilePath: string;
+    dotPnpmFolder: string;
+    executionTimeInMs: number;
+} | {
+    messageIdentifier: LogMessageIdentifier.COPY_STARTING;
+    pnpmSyncJsonPath: string;
+} | {
+    messageIdentifier: LogMessageIdentifier.COPY_ERROR_NO_SYNC_FILE;
+    pnpmSyncJsonPath: string;
+} | {
+    messageIdentifier: LogMessageIdentifier.COPY_FINISHING;
+    pnpmSyncJsonPath: string;
+    fileCount: number;
+    sourcePath: string;
+    executionTimeInMs: number;
+};
+
+// @beta (undocumented)
 export enum LogMessageIdentifier {
+    // (undocumented)
+    COPY_ERROR_NO_SYNC_FILE = "copy-error-no-sync-file",
     // (undocumented)
     COPY_FINISHING = "copy-finishing",
     // (undocumented)
-    COPY_PROCESSING = "copy-processing",
-    // (undocumented)
     COPY_STARTING = "copy-starting",
+    // (undocumented)
+    PREPARE_ERROR_UNSUPPORTED_FORMAT = "prepare-error-unsupported-format",
     // (undocumented)
     PREPARE_FINISHING = "prepare-finishing",
     // (undocumented)
     PREPARE_PROCESSING = "prepare-processing",
     // (undocumented)
-    PREPARE_STARTING = "prepare-starting"
+    PREPARE_STARTING = "prepare-starting",
+    // (undocumented)
+    PREPARE_WRITING_FILE = "prepare-writing-file"
 }
 
 // @beta (undocumented)
@@ -137,9 +143,9 @@ export enum LogMessageKind {
 }
 
 // @beta
-export function pnpmSyncCopyAsync({ pnpmSyncJsonPath, getPackageIncludedFiles, forEachAsyncWithConcurrency, ensureFolder, logMessageCallback }: IPnpmSyncCopyOptions): Promise<void>;
+export function pnpmSyncCopyAsync(options: IPnpmSyncCopyOptions): Promise<void>;
 
 // @beta
-export function pnpmSyncPrepareAsync({ lockfilePath, storePath, ensureFolder, readPnpmLockfile, logMessageCallback }: IPnpmSyncPrepareOptions): Promise<void>;
+export function pnpmSyncPrepareAsync(options: IPnpmSyncPrepareOptions): Promise<void>;
 
 ```

--- a/packages/pnpm-sync-lib/package.json
+++ b/packages/pnpm-sync-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync-lib",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "API library for integrating \"pnpm-sync\" with your toolchain",
   "repository": {
     "type": "git",

--- a/packages/pnpm-sync-lib/src/index.ts
+++ b/packages/pnpm-sync-lib/src/index.ts
@@ -7,7 +7,7 @@
 
 export { pnpmSyncCopyAsync, type IPnpmSyncCopyOptions } from './pnpmSyncCopy';
 export { pnpmSyncPrepareAsync, type IPnpmSyncPrepareOptions } from './pnpmSyncPrepare';
-export { LogMessageIdentifier, LogMessageKind } from './interfaces';
+export { LogMessageIdentifier, LogMessageKind, LogMessageDetails } from './interfaces';
 export type {
   ILockfile,
   ILockfileImporter,

--- a/packages/pnpm-sync-lib/src/interfaces.ts
+++ b/packages/pnpm-sync-lib/src/interfaces.ts
@@ -29,13 +29,64 @@ export enum LogMessageKind {
  * @beta
  */
 export enum LogMessageIdentifier {
+  // pnpmSyncPrepareAsync() messages
   PREPARE_STARTING = 'prepare-starting',
+  PREPARE_ERROR_UNSUPPORTED_FORMAT = 'prepare-error-unsupported-format',
   PREPARE_PROCESSING = 'prepare-processing',
+  PREPARE_WRITING_FILE = 'prepare-writing-file',
   PREPARE_FINISHING = 'prepare-finishing',
+
+  // pnpmSyncCopyAsync() messages
   COPY_STARTING = 'copy-starting',
-  COPY_PROCESSING = 'copy-processing',
+  COPY_ERROR_NO_SYNC_FILE = 'copy-error-no-sync-file',
   COPY_FINISHING = 'copy-finishing'
 }
+
+/**
+ * @beta
+ */
+export type LogMessageDetails =
+  | {
+      messageIdentifier: LogMessageIdentifier.PREPARE_STARTING;
+      lockfilePath: string;
+      dotPnpmFolder: string;
+    }
+  | {
+      messageIdentifier: LogMessageIdentifier.PREPARE_ERROR_UNSUPPORTED_FORMAT;
+      lockfilePath: string;
+      lockfileVersion: string | undefined;
+    }
+  | {
+      messageIdentifier: LogMessageIdentifier.PREPARE_PROCESSING;
+      lockfilePath: string;
+      dotPnpmFolderPath: string;
+    }
+  | {
+      messageIdentifier: LogMessageIdentifier.PREPARE_WRITING_FILE;
+      pnpmSyncJsonPath: string;
+      projectFolder: string;
+    }
+  | {
+      messageIdentifier: LogMessageIdentifier.PREPARE_FINISHING;
+      lockfilePath: string;
+      dotPnpmFolder: string;
+      executionTimeInMs: number;
+    }
+  | {
+      messageIdentifier: LogMessageIdentifier.COPY_STARTING;
+      pnpmSyncJsonPath: string;
+    }
+  | {
+      messageIdentifier: LogMessageIdentifier.COPY_ERROR_NO_SYNC_FILE;
+      pnpmSyncJsonPath: string;
+    }
+  | {
+      messageIdentifier: LogMessageIdentifier.COPY_FINISHING;
+      pnpmSyncJsonPath: string;
+      fileCount: number;
+      sourcePath: string;
+      executionTimeInMs: number;
+    };
 
 /**
  * @beta
@@ -43,37 +94,7 @@ export enum LogMessageIdentifier {
 export interface ILogMessageCallbackOptions {
   message: string;
   messageKind: LogMessageKind;
-  details:
-    | {
-        messageIdentifier: LogMessageIdentifier.PREPARE_STARTING;
-        lockfilePath: string;
-        dotPnpmFolderPath: string;
-      }
-    | {
-        messageIdentifier: LogMessageIdentifier.PREPARE_PROCESSING;
-        lockfilePath: string;
-        dotPnpmFolderPath: string;
-      }
-    | {
-        messageIdentifier: LogMessageIdentifier.PREPARE_FINISHING;
-        lockfilePath: string;
-        dotPnpmFolderPath: string;
-        executionTimeInMs: string;
-      }
-    | {
-        messageIdentifier: LogMessageIdentifier.COPY_STARTING;
-        pnpmSyncJsonPath: string;
-      }
-    | {
-        messageIdentifier: LogMessageIdentifier.COPY_PROCESSING;
-        pnpmSyncJsonPath: string;
-      }
-    | {
-        messageIdentifier: LogMessageIdentifier.COPY_FINISHING;
-        pnpmSyncJsonPath: string;
-        fileCount: number;
-        executionTimeInMs: string;
-      };
+  details: LogMessageDetails;
 }
 
 /**

--- a/packages/pnpm-sync/package.json
+++ b/packages/pnpm-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "Recopy injected dependencies whenever a project is rebuilt in your PNPM workspace",
   "keywords": [
     "rush",


### PR DESCRIPTION
These changes improve logging for https://github.com/microsoft/rushstack/pull/4594.

- To reduce confusion, rename `storePath` to `dotPnpmFolder` and avoid referring to it as the "store"
  👉 The PNPM **"store"** is a different folder from the **"virtual store"** (`.pnpm` folder), and PNPM itself is somewhat vague about whether the "virtual store" means the `.pnpm` folder or actually its subfolder paths

- Fix a bug where `postbuildInjectedCopy.sourceFolder` and `targetFolders` were calculated with an extra `..` because they were relative to `pnpmSyncJsonPath` which is a file, not a directory
- `pnpm-sync` CLI now returns nonzero exit code for errors/warnings
- Add `--verbose` CLI parameter for testing verbose events
- Provide an importable name for `ILogMessageCallbackOptions.details`
- Add API docs for `IPnpmSyncCopyOptions` and `IPnpmSyncPrepareOptions`
- Rename `COPY_PROCESSING` to ``COPY_ERROR_NO_SYNC_FILE` to more clearly indicate that it is an error.
- Introduce new log events `PREPARE_ERROR_UNSUPPORTED_FORMAT` and `PREPARE_WRITING_FILE`
- Add more `details` fields to the various log events
- The millisecond timings are now `number` instead of `string` to permit the caller to format them
- Remove `pnpm-sync:` prefix from log messages so the caller can do that
- Improve grammar to avoid a `Synced 1 files` message
- `IPnpmSyncCopyOptions.pnpmSyncJsonPath` is no longer optional because API's should not be designed around `process.cwd()` and also a correct implementation needs to test existence of that file before calling the API
- Remove `IPnpmSyncCopyOptions` parameter destructuring because this is an implementation detail that clutters the public API docs

@g-chao 