### PR TITLE
feat: support version in .pnpm-sync.json

### DIFF
--- a/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
+++ b/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
@@ -4,9 +4,6 @@
 
 ```ts
 
-// @beta
-export function getPnpmSyncJsonVersion(): string;
-
 // @beta (undocumented)
 export interface IDependencyMeta {
     // (undocumented)
@@ -91,6 +88,12 @@ export type LogMessageDetails = {
     lockfilePath: string;
     dotPnpmFolder: string;
 } | {
+    messageIdentifier: LogMessageIdentifier.PREPARE_REPLACING_FILE;
+    pnpmSyncJsonPath: string;
+    projectFolder: string;
+    actualVersion: string;
+    expectedVersion: string;
+} | {
     messageIdentifier: LogMessageIdentifier.PREPARE_WRITING_FILE;
     pnpmSyncJsonPath: string;
     projectFolder: string;
@@ -106,6 +109,11 @@ export type LogMessageDetails = {
     messageIdentifier: LogMessageIdentifier.COPY_ERROR_NO_SYNC_FILE;
     pnpmSyncJsonPath: string;
 } | {
+    messageIdentifier: LogMessageIdentifier.COPY_ERROR_INCOMPATIBLE_SYNC_FILE;
+    pnpmSyncJsonPath: string;
+    actualVersion: string;
+    expectedVersion: string;
+} | {
     messageIdentifier: LogMessageIdentifier.COPY_FINISHING;
     pnpmSyncJsonPath: string;
     fileCount: number;
@@ -115,6 +123,8 @@ export type LogMessageDetails = {
 
 // @beta (undocumented)
 export enum LogMessageIdentifier {
+    // (undocumented)
+    COPY_ERROR_INCOMPATIBLE_SYNC_FILE = "copy-error-incompatible-sync-file",
     // (undocumented)
     COPY_ERROR_NO_SYNC_FILE = "copy-error-no-sync-file",
     // (undocumented)
@@ -127,6 +137,8 @@ export enum LogMessageIdentifier {
     PREPARE_FINISHING = "prepare-finishing",
     // (undocumented)
     PREPARE_PROCESSING = "prepare-processing",
+    // (undocumented)
+    PREPARE_REPLACING_FILE = "prepare-replacing-file",
     // (undocumented)
     PREPARE_STARTING = "prepare-starting",
     // (undocumented)
@@ -147,6 +159,9 @@ export enum LogMessageKind {
 
 // @beta
 export function pnpmSyncCopyAsync(options: IPnpmSyncCopyOptions): Promise<void>;
+
+// @beta
+export function pnpmSyncGetJsonVersion(): string;
 
 // @beta
 export function pnpmSyncPrepareAsync(options: IPnpmSyncPrepareOptions): Promise<void>;

--- a/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
+++ b/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
@@ -4,6 +4,9 @@
 
 ```ts
 
+// @beta
+export function getPnpmSyncJsonVersion(): string;
+
 // @beta (undocumented)
 export interface IDependencyMeta {
     // (undocumented)
@@ -86,7 +89,7 @@ export type LogMessageDetails = {
 } | {
     messageIdentifier: LogMessageIdentifier.PREPARE_PROCESSING;
     lockfilePath: string;
-    dotPnpmFolderPath: string;
+    dotPnpmFolder: string;
 } | {
     messageIdentifier: LogMessageIdentifier.PREPARE_WRITING_FILE;
     pnpmSyncJsonPath: string;

--- a/packages/pnpm-sync-lib/package.json
+++ b/packages/pnpm-sync-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync-lib",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "API library for integrating \"pnpm-sync\" with your toolchain",
   "repository": {
     "type": "git",

--- a/packages/pnpm-sync-lib/src/index.ts
+++ b/packages/pnpm-sync-lib/src/index.ts
@@ -8,6 +8,7 @@
 export { pnpmSyncCopyAsync, type IPnpmSyncCopyOptions } from './pnpmSyncCopy';
 export { pnpmSyncPrepareAsync, type IPnpmSyncPrepareOptions } from './pnpmSyncPrepare';
 export { LogMessageIdentifier, LogMessageKind, LogMessageDetails } from './interfaces';
+export { getPnpmSyncJsonVersion } from './utilities';
 export type {
   ILockfile,
   ILockfileImporter,

--- a/packages/pnpm-sync-lib/src/index.ts
+++ b/packages/pnpm-sync-lib/src/index.ts
@@ -8,7 +8,7 @@
 export { pnpmSyncCopyAsync, type IPnpmSyncCopyOptions } from './pnpmSyncCopy';
 export { pnpmSyncPrepareAsync, type IPnpmSyncPrepareOptions } from './pnpmSyncPrepare';
 export { LogMessageIdentifier, LogMessageKind, LogMessageDetails } from './interfaces';
-export { getPnpmSyncJsonVersion } from './utilities';
+export { pnpmSyncGetJsonVersion } from './utilities';
 export type {
   ILockfile,
   ILockfileImporter,

--- a/packages/pnpm-sync-lib/src/interfaces.ts
+++ b/packages/pnpm-sync-lib/src/interfaces.ts
@@ -5,6 +5,7 @@ export interface IPnpmSyncCliArgs {
 }
 
 export interface IPnpmSyncJson {
+  version: string;
   postbuildInjectedCopy: {
     sourceFolder: string;
     targetFolders: Array<ITargetFolder>;
@@ -59,7 +60,7 @@ export type LogMessageDetails =
   | {
       messageIdentifier: LogMessageIdentifier.PREPARE_PROCESSING;
       lockfilePath: string;
-      dotPnpmFolderPath: string;
+      dotPnpmFolder: string;
     }
   | {
       messageIdentifier: LogMessageIdentifier.PREPARE_WRITING_FILE;

--- a/packages/pnpm-sync-lib/src/interfaces.ts
+++ b/packages/pnpm-sync-lib/src/interfaces.ts
@@ -34,12 +34,14 @@ export enum LogMessageIdentifier {
   PREPARE_STARTING = 'prepare-starting',
   PREPARE_ERROR_UNSUPPORTED_FORMAT = 'prepare-error-unsupported-format',
   PREPARE_PROCESSING = 'prepare-processing',
+  PREPARE_REPLACING_FILE = 'prepare-replacing-file',
   PREPARE_WRITING_FILE = 'prepare-writing-file',
   PREPARE_FINISHING = 'prepare-finishing',
 
   // pnpmSyncCopyAsync() messages
   COPY_STARTING = 'copy-starting',
   COPY_ERROR_NO_SYNC_FILE = 'copy-error-no-sync-file',
+  COPY_ERROR_INCOMPATIBLE_SYNC_FILE = 'copy-error-incompatible-sync-file',
   COPY_FINISHING = 'copy-finishing'
 }
 
@@ -63,6 +65,13 @@ export type LogMessageDetails =
       dotPnpmFolder: string;
     }
   | {
+      messageIdentifier: LogMessageIdentifier.PREPARE_REPLACING_FILE;
+      pnpmSyncJsonPath: string;
+      projectFolder: string;
+      actualVersion: string;
+      expectedVersion: string;
+    }
+  | {
       messageIdentifier: LogMessageIdentifier.PREPARE_WRITING_FILE;
       pnpmSyncJsonPath: string;
       projectFolder: string;
@@ -80,6 +89,12 @@ export type LogMessageDetails =
   | {
       messageIdentifier: LogMessageIdentifier.COPY_ERROR_NO_SYNC_FILE;
       pnpmSyncJsonPath: string;
+    }
+  | {
+      messageIdentifier: LogMessageIdentifier.COPY_ERROR_INCOMPATIBLE_SYNC_FILE;
+      pnpmSyncJsonPath: string;
+      actualVersion: string;
+      expectedVersion: string;
     }
   | {
       messageIdentifier: LogMessageIdentifier.COPY_FINISHING;

--- a/packages/pnpm-sync-lib/src/pnpmSyncCopy.ts
+++ b/packages/pnpm-sync-lib/src/pnpmSyncCopy.ts
@@ -7,7 +7,7 @@ import {
   LogMessageIdentifier,
   LogMessageKind
 } from './interfaces';
-import { getPnpmSyncJsonVersion } from './utilities';
+import { pnpmSyncGetJsonVersion } from './utilities';
 
 /**
  * @beta
@@ -102,17 +102,19 @@ export async function pnpmSyncCopyAsync(options: IPnpmSyncCopyOptions): Promise<
   // read the .pnpm-sync.json
   const pnpmSyncJson: IPnpmSyncJson = JSON.parse(pnpmSyncJsonContents);
 
-  // verify if the version is outdated
-  const pnpmSyncJsonVersion: string = getPnpmSyncJsonVersion();
-
-  if (pnpmSyncJsonVersion !== pnpmSyncJson.version) {
-    const errorMessage = `The .pnpm-sync.json file in ${pnpmSyncJsonFolder} is outdated; regenerate it and try again.`;
+  // verify if the version is incompatible
+  const expectedPnpmSyncJsonVersion: string = pnpmSyncGetJsonVersion();
+  const actualPnpmSyncJsonVersion: string = pnpmSyncJson.version;
+  if (expectedPnpmSyncJsonVersion !== actualPnpmSyncJsonVersion) {
+    const errorMessage = `The .pnpm-sync.json file in ${pnpmSyncJsonFolder} has an incompatible version; regenerate it and try again.`;
     logMessageCallback({
       message: errorMessage,
       messageKind: LogMessageKind.ERROR,
       details: {
-        messageIdentifier: LogMessageIdentifier.COPY_ERROR_NO_SYNC_FILE,
-        pnpmSyncJsonPath
+        messageIdentifier: LogMessageIdentifier.COPY_ERROR_INCOMPATIBLE_SYNC_FILE,
+        pnpmSyncJsonPath,
+        actualVersion: actualPnpmSyncJsonVersion,
+        expectedVersion: expectedPnpmSyncJsonVersion
       }
     });
     throw Error(errorMessage);

--- a/packages/pnpm-sync-lib/src/utilities.ts
+++ b/packages/pnpm-sync-lib/src/utilities.ts
@@ -1,0 +1,8 @@
+/**
+ * Get .pnpm-sync.json version
+ *
+ * @beta
+ */
+export function getPnpmSyncJsonVersion(): string {
+  return require('../package.json').version;
+}

--- a/packages/pnpm-sync-lib/src/utilities.ts
+++ b/packages/pnpm-sync-lib/src/utilities.ts
@@ -3,6 +3,6 @@
  *
  * @beta
  */
-export function getPnpmSyncJsonVersion(): string {
+export function pnpmSyncGetJsonVersion(): string {
   return require('../package.json').version;
 }

--- a/packages/pnpm-sync/package.json
+++ b/packages/pnpm-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Recopy injected dependencies whenever a project is rebuilt in your PNPM workspace",
   "keywords": [
     "rush",

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
@@ -102,7 +102,7 @@ describe('pnpm-sync-api copy test', () => {
         Object {
           "details": Object {
             "executionTimeInMs": "[TIMING]",
-            "fileCount": 3,
+            "fileCount": 6,
             "messageIdentifier": "copy-finishing",
             "pnpmSyncJsonPath": "<root>/pnpm-sync/tests/test-fixtures/sample-lib1/node_modules/.pnpm-sync.json",
             "sourcePath": "<root>/pnpm-sync/tests/test-fixtures/sample-lib1",

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
@@ -5,12 +5,12 @@ import { PackageExtractor } from '@rushstack/package-extractor';
 import { readPnpmLockfile, scrubLog } from './testUtilities';
 import {
   ILogMessageCallbackOptions,
-  getPnpmSyncJsonVersion,
+  pnpmSyncGetJsonVersion,
   pnpmSyncCopyAsync,
   pnpmSyncPrepareAsync
 } from 'pnpm-sync-lib';
 
-const pnpmSyncLibVersion: string = getPnpmSyncJsonVersion();
+const pnpmSyncLibVersion: string = pnpmSyncGetJsonVersion();
 
 describe('pnpm-sync-api copy test', () => {
   it('pnpmSyncCopyAsync should copy files based on .pnpm-sync.json under node_modules folder', async () => {
@@ -47,10 +47,10 @@ describe('pnpm-sync-api copy test', () => {
     });
 
     // set a outdated version
-    pnpmSyncJsonFile.version = 'outdated-version';
+    pnpmSyncJsonFile.version = 'incompatible-version';
     await fs.promises.writeFile(pnpmSyncJsonPath, JSON.stringify(pnpmSyncJsonFile, null, 2));
 
-    // if pnpmSyncCopyAsync detects a outdated version, should throw errors
+    // if pnpmSyncCopyAsync detects a incompatible version, should throw errors
     try {
       await pnpmSyncCopyAsync({
         pnpmSyncJsonPath,
@@ -60,7 +60,7 @@ describe('pnpm-sync-api copy test', () => {
         logMessageCallback: () => {}
       });
     } catch (error) {
-      expect(error.message).toContain('is outdated; regenerate it and try again');
+      expect(error.message).toContain('has an incompatible version; regenerate it and try again');
     }
 
     // set the correct version

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
@@ -1,0 +1,116 @@
+import fs from 'fs';
+import path from 'path';
+import { Async, FileSystem } from '@rushstack/node-core-library';
+import { PackageExtractor } from '@rushstack/package-extractor';
+import { readPnpmLockfile, scrubLog } from './testUtilities';
+import {
+  ILogMessageCallbackOptions,
+  getPnpmSyncJsonVersion,
+  pnpmSyncCopyAsync,
+  pnpmSyncPrepareAsync
+} from 'pnpm-sync-lib';
+
+const pnpmSyncLibVersion: string = getPnpmSyncJsonVersion();
+
+describe('pnpm-sync-api copy test', () => {
+  it('pnpmSyncCopyAsync should copy files based on .pnpm-sync.json under node_modules folder', async () => {
+    const lockfilePath = '../../pnpm-lock.yaml';
+    const dotPnpmFolder = '../../node_modules/.pnpm';
+
+    const pnpmSyncJsonFolder = `../test-fixtures/sample-lib1/node_modules`;
+    const pnpmSyncJsonPath = `${pnpmSyncJsonFolder}/.pnpm-sync.json`;
+    const targetFolderPath =
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib1';
+    // generate .pnpm-sync.json file first.
+    await pnpmSyncPrepareAsync({
+      lockfilePath: lockfilePath,
+      dotPnpmFolder: dotPnpmFolder,
+      ensureFolder: FileSystem.ensureFolderAsync,
+      readPnpmLockfile,
+      logMessageCallback: (): void => {}
+    });
+
+    // make sure .pnpm-sync.json exists
+    expect(fs.existsSync(pnpmSyncJsonPath)).toBe(true);
+
+    const pnpmSyncJsonFile = JSON.parse(fs.readFileSync(pnpmSyncJsonPath).toString());
+    expect(pnpmSyncJsonFile).toEqual({
+      version: pnpmSyncLibVersion,
+      postbuildInjectedCopy: {
+        sourceFolder: '..',
+        targetFolders: [
+          {
+            folderPath: targetFolderPath
+          }
+        ]
+      }
+    });
+
+    // set a outdated version
+    pnpmSyncJsonFile.version = 'outdated-version';
+    await fs.promises.writeFile(pnpmSyncJsonPath, JSON.stringify(pnpmSyncJsonFile, null, 2));
+
+    // if pnpmSyncCopyAsync detects a outdated version, should throw errors
+    try {
+      await pnpmSyncCopyAsync({
+        pnpmSyncJsonPath,
+        getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
+        forEachAsyncWithConcurrency: Async.forEachAsync,
+        ensureFolder: FileSystem.ensureFolderAsync,
+        logMessageCallback: () => {}
+      });
+    } catch (error) {
+      expect(error.message).toContain('is outdated; regenerate it and try again');
+    }
+
+    // set the correct version
+    pnpmSyncJsonFile.version = pnpmSyncLibVersion;
+    await fs.promises.writeFile(pnpmSyncJsonPath, JSON.stringify(pnpmSyncJsonFile, null, 2));
+
+    const destinationPath = path.resolve(pnpmSyncJsonFolder, targetFolderPath);
+
+    // delete the destination folder
+    await fs.promises.rm(destinationPath, { recursive: true, force: true });
+    expect(fs.existsSync(destinationPath)).toBe(false);
+
+    const logs: ILogMessageCallbackOptions[] = [];
+
+    await pnpmSyncCopyAsync({
+      pnpmSyncJsonPath,
+      getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
+      forEachAsyncWithConcurrency: Async.forEachAsync,
+      ensureFolder: FileSystem.ensureFolderAsync,
+      logMessageCallback: (options: ILogMessageCallbackOptions): void => {
+        logs.push(options);
+      }
+    });
+
+    // after copy action, the destination folder should exists
+    expect(fs.existsSync(destinationPath)).toBe(true);
+
+    // check the log message
+    expect(logs.map((x) => scrubLog(x))).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "details": Object {
+            "messageIdentifier": "copy-starting",
+            "pnpmSyncJsonPath": "<root>/pnpm-sync/tests/test-fixtures/sample-lib1/node_modules/.pnpm-sync.json",
+          },
+          "message": "Starting...",
+          "messageKind": "verbose",
+        },
+        Object {
+          "details": Object {
+            "executionTimeInMs": "[TIMING]",
+            "fileCount": 3,
+            "messageIdentifier": "copy-finishing",
+            "pnpmSyncJsonPath": "<root>/pnpm-sync/tests/test-fixtures/sample-lib1/node_modules/.pnpm-sync.json",
+            "sourcePath": "<root>/pnpm-sync/tests/test-fixtures/sample-lib1",
+          },
+          "message": "Synced...",
+          "messageKind": "info",
+        },
+      ]
+    `);
+  });
+});

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
@@ -1,48 +1,17 @@
 import fs from 'fs';
 import path from 'path';
-import { FileSystem, Path } from '@rushstack/node-core-library';
-import { readWantedLockfile, Lockfile } from '@pnpm/lockfile-file';
+import { FileSystem } from '@rushstack/node-core-library';
 import {
-  type ILockfile,
-  type ILockfilePackage,
   pnpmSyncPrepareAsync,
   ILogMessageCallbackOptions,
-  LogMessageIdentifier
+  LogMessageIdentifier,
+  getPnpmSyncJsonVersion
 } from 'pnpm-sync-lib';
+import { readPnpmLockfile, scrubLog } from './testUtilities';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function scrubLog(log: Record<string, any>): Record<string, any> {
-  const scrubbedLog = { ...log };
-  const repoRootFolder = path.join(__dirname, '..', '..', '..', '..', '..');
-  for (const key of Object.keys(scrubbedLog)) {
-    switch (key) {
-      case 'message':
-        scrubbedLog[key] = scrubbedLog[key].split(' ')[0] + '...';
-        break;
-      case 'details':
-        scrubbedLog[key] = scrubLog(scrubbedLog[key]);
-        break;
-      case 'executionTimeInMs':
-        scrubbedLog[key] = '[TIMING]';
-        break;
+const pnpmSyncLibVersion: string = getPnpmSyncJsonVersion();
 
-      case 'dotPnpmFolder':
-      case 'dotPnpmFolderPath':
-      case 'lockfilePath':
-      case 'pnpmSyncJsonPath':
-      case 'projectFolder':
-      case 'sourcePath':
-        let scrubbedPath = scrubbedLog[key];
-        scrubbedPath = scrubbedPath.replace(repoRootFolder, '<root>');
-        scrubbedPath = Path.convertToSlashes(scrubbedPath);
-        scrubbedLog[key] = scrubbedPath;
-        break;
-    }
-  }
-  return scrubbedLog;
-}
-
-describe('pnpm-sync-api test', () => {
+describe('pnpm-sync-api prepare test', () => {
   it('pnpmSyncPrepareAsync should generate .pnpm-sync.json under node_modules folder', async () => {
     const lockfilePath = '../../pnpm-lock.yaml';
     const dotPnpmFolder = '../../node_modules/.pnpm';
@@ -69,30 +38,7 @@ describe('pnpm-sync-api test', () => {
       lockfilePath: lockfilePath,
       dotPnpmFolder: dotPnpmFolder,
       ensureFolder: FileSystem.ensureFolderAsync,
-      readPnpmLockfile: async (
-        lockfilePath: string,
-        options: {
-          ignoreIncompatible: boolean;
-        }
-      ) => {
-        const pnpmLockFolder = path.dirname(lockfilePath);
-        const lockfile: Lockfile | null = await readWantedLockfile(pnpmLockFolder, options);
-
-        if (lockfile === null) {
-          return undefined;
-        } else {
-          const lockfilePackages: Record<string, ILockfilePackage> = lockfile.packages as Record<
-            string,
-            ILockfilePackage
-          >;
-          const result: ILockfile = {
-            lockfileVersion: lockfile.lockfileVersion,
-            importers: lockfile.importers,
-            packages: lockfilePackages
-          };
-          return result;
-        }
-      },
+      readPnpmLockfile,
       logMessageCallback: (options: ILogMessageCallbackOptions): void => {
         // in this test case, we only care projects under tests/test-fixtures folder
         if (
@@ -151,6 +97,7 @@ describe('pnpm-sync-api test', () => {
     expect(fs.existsSync(dotPnpmSyncJsonPathForSampleLib2)).toBe(true);
 
     expect(JSON.parse(fs.readFileSync(dotPnpmSyncJsonPathForSampleLib1).toString())).toEqual({
+      version: pnpmSyncLibVersion,
       postbuildInjectedCopy: {
         sourceFolder: '..',
         targetFolders: [
@@ -163,12 +110,99 @@ describe('pnpm-sync-api test', () => {
     });
 
     expect(JSON.parse(fs.readFileSync(dotPnpmSyncJsonPathForSampleLib2).toString())).toEqual({
+      version: pnpmSyncLibVersion,
       postbuildInjectedCopy: {
         sourceFolder: '..',
         targetFolders: [
           {
             folderPath:
               '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/api-demo-sample-lib2'
+          }
+        ]
+      }
+    });
+  });
+
+  it('pnpmSyncPrepareAsync should detect outdated .pnpm-sync.json version', async () => {
+    const lockfilePath = '../../pnpm-lock.yaml';
+    const dotPnpmFolder = '../../node_modules/.pnpm';
+
+    const pnpmSyncJsonFolder = `../test-fixtures/sample-lib1/node_modules`;
+    const pnpmSyncJsonPath = `${pnpmSyncJsonFolder}/.pnpm-sync.json`;
+
+    if (!fs.existsSync(pnpmSyncJsonFolder)) {
+      await FileSystem.ensureFolderAsync(pnpmSyncJsonFolder);
+    }
+
+    // fake a .pnpm-sync.json for testing
+    const fakePnpmSyncJsonFile = {
+      version: 'fake-version',
+      postbuildInjectedCopy: {
+        sourceFolder: '..',
+        targetFolders: ['../../../../node_modules/.pnpm/fake+folder']
+      }
+    };
+
+    // write a fake .pnpm-sync.json
+    await fs.promises.writeFile(pnpmSyncJsonPath, JSON.stringify(fakePnpmSyncJsonFile, null, 2));
+
+    const logs: ILogMessageCallbackOptions[] = [];
+
+    await pnpmSyncPrepareAsync({
+      lockfilePath: lockfilePath,
+      dotPnpmFolder: dotPnpmFolder,
+      ensureFolder: FileSystem.ensureFolderAsync,
+      readPnpmLockfile,
+      logMessageCallback: (options: ILogMessageCallbackOptions): void => {
+        // in this test case, we only care projects under tests/test-fixtures/sample-lib1 folder
+        // and the logs related to write files
+        if (
+          options.details.messageIdentifier === LogMessageIdentifier.PREPARE_WRITING_FILE &&
+          options.details.projectFolder
+            .split(path.sep)
+            .join(path.posix.sep)
+            .includes('tests/test-fixtures/sample-lib1')
+        ) {
+          logs.push(options);
+        }
+      }
+    });
+
+    expect(logs.map((x) => scrubLog(x))).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "details": Object {
+            "messageIdentifier": "prepare-writing-file",
+            "pnpmSyncJsonPath": "<root>/pnpm-sync/tests/test-fixtures/sample-lib1/node_modules/.pnpm-sync.json",
+            "projectFolder": "<root>/pnpm-sync/tests/test-fixtures/sample-lib1",
+          },
+          "message": "Writing...",
+          "messageKind": "verbose",
+        },
+        Object {
+          "details": Object {
+            "messageIdentifier": "prepare-writing-file",
+            "pnpmSyncJsonPath": "<root>/pnpm-sync/tests/test-fixtures/sample-lib1/node_modules/.pnpm-sync.json",
+            "projectFolder": "<root>/pnpm-sync/tests/test-fixtures/sample-lib1",
+          },
+          "message": "The...",
+          "messageKind": "verbose",
+        },
+      ]
+    `);
+
+    // now, read .pnpm-sync.json and check the fields
+    expect(fs.existsSync(pnpmSyncJsonPath)).toBe(true);
+
+    // the fake a .pnpm-sync.json should be replaced with the correct one
+    expect(JSON.parse(fs.readFileSync(pnpmSyncJsonPath).toString())).toEqual({
+      version: pnpmSyncLibVersion,
+      postbuildInjectedCopy: {
+        sourceFolder: '..',
+        targetFolders: [
+          {
+            folderPath:
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib1'
           }
         ]
       }

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
@@ -5,11 +5,11 @@ import {
   pnpmSyncPrepareAsync,
   ILogMessageCallbackOptions,
   LogMessageIdentifier,
-  getPnpmSyncJsonVersion
+  pnpmSyncGetJsonVersion
 } from 'pnpm-sync-lib';
 import { readPnpmLockfile, scrubLog } from './testUtilities';
 
-const pnpmSyncLibVersion: string = getPnpmSyncJsonVersion();
+const pnpmSyncLibVersion: string = pnpmSyncGetJsonVersion();
 
 describe('pnpm-sync-api prepare test', () => {
   it('pnpmSyncPrepareAsync should generate .pnpm-sync.json under node_modules folder', async () => {
@@ -134,9 +134,9 @@ describe('pnpm-sync-api prepare test', () => {
       await FileSystem.ensureFolderAsync(pnpmSyncJsonFolder);
     }
 
-    // fake a .pnpm-sync.json for testing
+    // create an incompatible .pnpm-sync.json for testing
     const fakePnpmSyncJsonFile = {
-      version: 'fake-version',
+      version: 'incompatible-version',
       postbuildInjectedCopy: {
         sourceFolder: '..',
         targetFolders: ['../../../../node_modules/.pnpm/fake+folder']
@@ -157,7 +157,7 @@ describe('pnpm-sync-api prepare test', () => {
         // in this test case, we only care projects under tests/test-fixtures/sample-lib1 folder
         // and the logs related to write files
         if (
-          options.details.messageIdentifier === LogMessageIdentifier.PREPARE_WRITING_FILE &&
+          options.details.messageIdentifier === LogMessageIdentifier.PREPARE_REPLACING_FILE &&
           options.details.projectFolder
             .split(path.sep)
             .join(path.posix.sep)
@@ -172,16 +172,9 @@ describe('pnpm-sync-api prepare test', () => {
       Array [
         Object {
           "details": Object {
-            "messageIdentifier": "prepare-writing-file",
-            "pnpmSyncJsonPath": "<root>/pnpm-sync/tests/test-fixtures/sample-lib1/node_modules/.pnpm-sync.json",
-            "projectFolder": "<root>/pnpm-sync/tests/test-fixtures/sample-lib1",
-          },
-          "message": "Writing...",
-          "messageKind": "verbose",
-        },
-        Object {
-          "details": Object {
-            "messageIdentifier": "prepare-writing-file",
+            "actualVersion": "incompatible-version",
+            "expectedVersion": "0.2.1",
+            "messageIdentifier": "prepare-replacing-file",
             "pnpmSyncJsonPath": "<root>/pnpm-sync/tests/test-fixtures/sample-lib1/node_modules/.pnpm-sync.json",
             "projectFolder": "<root>/pnpm-sync/tests/test-fixtures/sample-lib1",
           },

--- a/tests/pnpm-sync-api-test/src/test/testUtilities.ts
+++ b/tests/pnpm-sync-api-test/src/test/testUtilities.ts
@@ -1,0 +1,61 @@
+import path from 'path';
+import { Lockfile, readWantedLockfile } from '@pnpm/lockfile-file';
+import { Path } from '@rushstack/node-core-library';
+import type { ILockfile, ILockfilePackage } from 'pnpm-sync-lib';
+
+export async function readPnpmLockfile(
+  lockfilePath: string,
+  options: {
+    ignoreIncompatible: boolean;
+  }
+): Promise<ILockfile | undefined> {
+  const pnpmLockFolder = path.dirname(lockfilePath);
+  const lockfile: Lockfile | null = await readWantedLockfile(pnpmLockFolder, options);
+
+  if (lockfile === null) {
+    return undefined;
+  } else {
+    const lockfilePackages: Record<string, ILockfilePackage> = lockfile.packages as Record<
+      string,
+      ILockfilePackage
+    >;
+    const result: ILockfile = {
+      lockfileVersion: lockfile.lockfileVersion,
+      importers: lockfile.importers,
+      packages: lockfilePackages
+    };
+    return result;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function scrubLog(log: Record<string, any>): Record<string, any> {
+  const scrubbedLog = { ...log };
+  const repoRootFolder = path.join(__dirname, '..', '..', '..', '..', '..');
+  for (const key of Object.keys(scrubbedLog)) {
+    switch (key) {
+      case 'message':
+        scrubbedLog[key] = scrubbedLog[key].split(' ')[0] + '...';
+        break;
+      case 'details':
+        scrubbedLog[key] = scrubLog(scrubbedLog[key]);
+        break;
+      case 'executionTimeInMs':
+        scrubbedLog[key] = '[TIMING]';
+        break;
+
+      case 'dotPnpmFolder':
+      case 'dotPnpmFolderPath':
+      case 'lockfilePath':
+      case 'pnpmSyncJsonPath':
+      case 'projectFolder':
+      case 'sourcePath':
+        let scrubbedPath = scrubbedLog[key];
+        scrubbedPath = scrubbedPath.replace(repoRootFolder, '<root>');
+        scrubbedPath = Path.convertToSlashes(scrubbedPath);
+        scrubbedLog[key] = scrubbedPath;
+        break;
+    }
+  }
+  return scrubbedLog;
+}


### PR DESCRIPTION
### Summary
This PR is to fix https://github.com/tiktok/pnpm-sync/issues/22. Add a version field in the `.pnpm-sync.json`.
### Details
1. The version in the package.json file will be written into  `.pnpm-sync.json`.
2. During `pnpm-sync prepare`, if an outdated version detected, then the `.pnpm-sync.json` file will be generated from scratch. 
3. During `pnpm-sync copy`, if an outdated version detected, then `pnpm-sync` will throw an error notify users to regenerate the `.pnpm-sync.json`
### How it was tested
Tested with test cases under `tests/pnpm-sync-api-test`