### PR TITLE
feat: incremental copy

### DIFF
--- a/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
+++ b/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
@@ -48,7 +48,7 @@ export interface ILogMessageCallbackOptions {
 
 // @beta (undocumented)
 export interface IPnpmSyncCopyOptions {
-    ensureFolder: (folderPath: string) => Promise<void>;
+    ensureFolderAsync: (folderPath: string) => Promise<void>;
     forEachAsyncWithConcurrency: <TItem>(iterable: Iterable<TItem>, callback: (item: TItem) => Promise<void>, options: {
         concurrency: number;
     }) => Promise<void>;
@@ -60,7 +60,7 @@ export interface IPnpmSyncCopyOptions {
 // @beta (undocumented)
 export interface IPnpmSyncPrepareOptions {
     dotPnpmFolder: string;
-    ensureFolder: (folderPath: string) => Promise<void>;
+    ensureFolderAsync: (folderPath: string) => Promise<void>;
     lockfilePath: string;
     logMessageCallback: (options: ILogMessageCallbackOptions) => void;
     readPnpmLockfile: (lockfilePath: string, options: {

--- a/packages/pnpm-sync-lib/package.json
+++ b/packages/pnpm-sync-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync-lib",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "API library for integrating \"pnpm-sync\" with your toolchain",
   "repository": {
     "type": "git",

--- a/packages/pnpm-sync-lib/src/interfaces.ts
+++ b/packages/pnpm-sync-lib/src/interfaces.ts
@@ -16,9 +16,8 @@ export interface ITargetFolder {
   folderPath: string;
 }
 
-export interface IFileStat {
-  file: string;
-  ino: number;
+export interface ISyncItem {
+  absolutePath: string;
   isDirectory: boolean;
   isFile: boolean;
 }

--- a/packages/pnpm-sync-lib/src/interfaces.ts
+++ b/packages/pnpm-sync-lib/src/interfaces.ts
@@ -16,6 +16,13 @@ export interface ITargetFolder {
   folderPath: string;
 }
 
+export interface IFileStat {
+  file: string;
+  ino: number;
+  isDirectory: boolean;
+  isFile: boolean;
+}
+
 /**
  * @beta
  */

--- a/packages/pnpm-sync-lib/src/pnpmSyncCopy.ts
+++ b/packages/pnpm-sync-lib/src/pnpmSyncCopy.ts
@@ -159,6 +159,8 @@ export async function pnpmSyncCopyAsync(options: IPnpmSyncCopyOptions): Promise<
           await fs.promises.link(copySourcePath, copyDestinationPath);
         } else {
           // if exist in target folder, check if it still point to the source Inode number
+          // in our copy implementation, we use hard link to copy files
+          // so that, we can utilize the file inode info to determine the equality of two files
           if (
             targetFolderFileToIsProcessed.get(copyDestinationPath)?.ino !== fs.statSync(copySourcePath).ino
           ) {

--- a/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
+++ b/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
@@ -33,7 +33,7 @@ export interface IPnpmSyncPrepareOptions {
    * Environment-provided API to avoid an NPM dependency.
    * The "pnpm-sync" NPM package provides a reference implementation.
    */
-  ensureFolder: (folderPath: string) => Promise<void>;
+  ensureFolderAsync: (folderPath: string) => Promise<void>;
 
   /**
    * Environment-provided API to avoid an NPM dependency.
@@ -63,7 +63,7 @@ export interface IPnpmSyncPrepareOptions {
  * @beta
  */
 export async function pnpmSyncPrepareAsync(options: IPnpmSyncPrepareOptions): Promise<void> {
-  const { ensureFolder, readPnpmLockfile, logMessageCallback } = options;
+  const { ensureFolderAsync, readPnpmLockfile, logMessageCallback } = options;
   let { lockfilePath, dotPnpmFolder } = options;
 
   // get the pnpm-lock.yaml path
@@ -186,7 +186,7 @@ export async function pnpmSyncPrepareAsync(options: IPnpmSyncPrepareOptions): Pr
     // it is possible that node_modules folder for a package is not exist yet
     // but we need to generate .pnpm-sync.json for that package
     if (!fs.existsSync(pnpmSyncJsonFolder)) {
-      await ensureFolder(pnpmSyncJsonFolder);
+      await ensureFolderAsync(pnpmSyncJsonFolder);
     }
 
     const expectedPnpmSyncJsonVersion: string = pnpmSyncGetJsonVersion();

--- a/packages/pnpm-sync-lib/src/utilities.ts
+++ b/packages/pnpm-sync-lib/src/utilities.ts
@@ -1,3 +1,7 @@
+import fs from 'fs';
+import path from 'path';
+import { IFileStat } from './interfaces';
+
 /**
  * Get .pnpm-sync.json version
  *
@@ -5,4 +9,41 @@
  */
 export function pnpmSyncGetJsonVersion(): string {
   return require('../package.json').version;
+}
+
+export function getFilesInDirectory(directory: string, includeDirectory: boolean): Array<IFileStat> {
+  const returnFileList: Array<IFileStat> = [];
+  getFilesInDirectoryHelper(directory, includeDirectory, returnFileList);
+  return returnFileList;
+}
+
+function getFilesInDirectoryHelper(
+  directory: string,
+  includeDirectory: boolean,
+  returnFileList: Array<IFileStat>
+): void {
+  const fileList = fs.readdirSync(directory);
+
+  for (const fileName of fileList) {
+    const absoluteFileName: string = path.join(directory, fileName);
+    const fileStat = fs.statSync(absoluteFileName);
+    if (fileStat.isDirectory()) {
+      if (includeDirectory) {
+        returnFileList.push({
+          file: absoluteFileName,
+          ino: fileStat.ino,
+          isDirectory: true,
+          isFile: false
+        });
+      }
+      getFilesInDirectoryHelper(absoluteFileName, includeDirectory, returnFileList);
+    } else {
+      returnFileList.push({
+        file: absoluteFileName,
+        ino: fileStat.ino,
+        isDirectory: false,
+        isFile: true
+      });
+    }
+  }
 }

--- a/packages/pnpm-sync/package.json
+++ b/packages/pnpm-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Recopy injected dependencies whenever a project is rebuilt in your PNPM workspace",
   "keywords": [
     "rush",

--- a/packages/pnpm-sync/src/start.ts
+++ b/packages/pnpm-sync/src/start.ts
@@ -51,7 +51,7 @@ program
         pnpmSyncJsonPath: process.cwd() + '/node_modules/.pnpm-sync.json',
         getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
         forEachAsyncWithConcurrency: Async.forEachAsync,
-        ensureFolder: FileSystem.ensureFolderAsync,
+        ensureFolderAsync: FileSystem.ensureFolderAsync,
         logMessageCallback: logMessage
       });
     } catch (error) {
@@ -74,7 +74,7 @@ program
       await pnpmSyncPrepareAsync({
         lockfilePath: lockfile,
         dotPnpmFolder: store,
-        ensureFolder: FileSystem.ensureFolderAsync,
+        ensureFolderAsync: FileSystem.ensureFolderAsync,
         readPnpmLockfile: async (
           lockfilePath: string,
           options: {

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
@@ -13,38 +13,65 @@ import {
 const pnpmSyncLibVersion: string = pnpmSyncGetJsonVersion();
 
 describe('pnpm-sync-api copy test', () => {
-  it('pnpmSyncCopyAsync should copy files based on .pnpm-sync.json under node_modules folder', async () => {
+  beforeAll(async () => {
     const lockfilePath = '../../pnpm-lock.yaml';
     const dotPnpmFolder = '../../node_modules/.pnpm';
 
-    const pnpmSyncJsonFolder = `../test-fixtures/sample-lib1/node_modules`;
-    const pnpmSyncJsonPath = `${pnpmSyncJsonFolder}/.pnpm-sync.json`;
-    const targetFolderPath =
-      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib1';
     // generate .pnpm-sync.json file first.
     await pnpmSyncPrepareAsync({
       lockfilePath: lockfilePath,
       dotPnpmFolder: dotPnpmFolder,
-      ensureFolder: FileSystem.ensureFolderAsync,
+      ensureFolderAsync: FileSystem.ensureFolderAsync,
       readPnpmLockfile,
       logMessageCallback: (): void => {}
     });
 
-    // make sure .pnpm-sync.json exists
-    expect(fs.existsSync(pnpmSyncJsonPath)).toBe(true);
+    const pnpmSyncJsonFolder1 = `../test-fixtures/sample-lib1/node_modules`;
+    const pnpmSyncJsonFolder2 = `../test-fixtures/sample-lib2/node_modules`;
 
-    const pnpmSyncJsonFile = JSON.parse(fs.readFileSync(pnpmSyncJsonPath).toString());
-    expect(pnpmSyncJsonFile).toEqual({
+    const pnpmSyncJsonPath1 = `${pnpmSyncJsonFolder1}/.pnpm-sync.json`;
+    const pnpmSyncJsonPath2 = `${pnpmSyncJsonFolder2}/.pnpm-sync.json`;
+
+    const targetFolderPath1 =
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib1';
+    const targetFolderPath2 =
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/api-demo-sample-lib2';
+
+    // make sure .pnpm-sync.json exists
+    expect(fs.existsSync(pnpmSyncJsonPath1)).toBe(true);
+    expect(fs.existsSync(pnpmSyncJsonPath2)).toBe(true);
+
+    expect(JSON.parse(fs.readFileSync(pnpmSyncJsonPath1).toString())).toEqual({
       version: pnpmSyncLibVersion,
       postbuildInjectedCopy: {
         sourceFolder: '..',
         targetFolders: [
           {
-            folderPath: targetFolderPath
+            folderPath: targetFolderPath1
           }
         ]
       }
     });
+    expect(JSON.parse(fs.readFileSync(pnpmSyncJsonPath2).toString())).toEqual({
+      version: pnpmSyncLibVersion,
+      postbuildInjectedCopy: {
+        sourceFolder: '..',
+        targetFolders: [
+          {
+            folderPath: targetFolderPath2
+          }
+        ]
+      }
+    });
+  });
+
+  it('pnpmSyncCopyAsync should copy files based on .pnpm-sync.json under node_modules folder', async () => {
+    const pnpmSyncJsonFolder = `../test-fixtures/sample-lib1/node_modules`;
+    const pnpmSyncJsonPath = `${pnpmSyncJsonFolder}/.pnpm-sync.json`;
+
+    const targetFolderPath =
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib1';
+    const pnpmSyncJsonFile = JSON.parse(fs.readFileSync(pnpmSyncJsonPath).toString());
 
     // set a outdated version
     pnpmSyncJsonFile.version = 'incompatible-version';
@@ -56,7 +83,7 @@ describe('pnpm-sync-api copy test', () => {
         pnpmSyncJsonPath,
         getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
         forEachAsyncWithConcurrency: Async.forEachAsync,
-        ensureFolder: FileSystem.ensureFolderAsync,
+        ensureFolderAsync: FileSystem.ensureFolderAsync,
         logMessageCallback: () => {}
       });
     } catch (error) {
@@ -73,25 +100,13 @@ describe('pnpm-sync-api copy test', () => {
     await fs.promises.rm(destinationPath, { recursive: true, force: true });
     expect(fs.existsSync(destinationPath)).toBe(false);
 
-    // now let put some random files and directories in the destination folder
-    // this is to test the incremental copy, the pnpmSyncCopyAsync needs be able to delete them correctly
-    await FileSystem.ensureFolderAsync(destinationPath);
-    const testTempFolder: string = path.join(destinationPath, 'tempFolder');
-    const testTempFile: string = path.join(destinationPath, 'tempFile.js');
-    fs.mkdirSync(testTempFolder);
-    fs.writeFileSync(testTempFile, 'console.log("Hello World!")');
-
-    // make sure we created these temp files successfully
-    expect(fs.existsSync(testTempFolder)).toBe(true);
-    expect(fs.existsSync(testTempFile)).toBe(true);
-
     const logs: ILogMessageCallbackOptions[] = [];
 
     await pnpmSyncCopyAsync({
       pnpmSyncJsonPath,
       getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
       forEachAsyncWithConcurrency: Async.forEachAsync,
-      ensureFolder: FileSystem.ensureFolderAsync,
+      ensureFolderAsync: FileSystem.ensureFolderAsync,
       logMessageCallback: (options: ILogMessageCallbackOptions): void => {
         logs.push(options);
       }
@@ -99,10 +114,6 @@ describe('pnpm-sync-api copy test', () => {
 
     // after copy action, the destination folder should exists
     expect(fs.existsSync(destinationPath)).toBe(true);
-
-    // and temp folder and file should be deleted
-    expect(fs.existsSync(testTempFolder)).toBe(false);
-    expect(fs.existsSync(testTempFile)).toBe(false);
 
     // and the real files should be there
     expect(fs.existsSync(path.join(destinationPath, 'src/index.ts'))).toBe(true);
@@ -132,5 +143,81 @@ describe('pnpm-sync-api copy test', () => {
         },
       ]
     `);
+  });
+
+  it('pnpmSyncCopyAsync should handle incremental copy', async () => {
+    const pnpmSyncJsonFolder = `../test-fixtures/sample-lib2/node_modules`;
+    const pnpmSyncJsonPath = `${pnpmSyncJsonFolder}/.pnpm-sync.json`;
+
+    const targetFolderPath =
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/api-demo-sample-lib2';
+
+    const destinationPath = path.resolve(pnpmSyncJsonFolder, targetFolderPath);
+    const sourcePath = '../test-fixtures/sample-lib2';
+
+    // let's do copy action first
+    await pnpmSyncCopyAsync({
+      pnpmSyncJsonPath,
+      getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
+      forEachAsyncWithConcurrency: Async.forEachAsync,
+      ensureFolderAsync: FileSystem.ensureFolderAsync,
+      logMessageCallback: (): void => {}
+    });
+
+    // after copy action, the destination folder should exists
+    expect(fs.existsSync(destinationPath)).toBe(true);
+
+    const destinationPackageJsonPath = path.join(destinationPath, 'package.json');
+    const destinationIndexFilePath = path.join(destinationPath, 'dist/index.js');
+
+    // and the files should be there
+    expect(fs.existsSync(destinationPackageJsonPath)).toBe(true);
+    expect(fs.existsSync(destinationIndexFilePath)).toBe(true);
+
+    // let get the file info of package.json in destination folder
+    const oldDestinationPackageJsonStat = fs.statSync(destinationPackageJsonPath);
+
+    // now let do some file operations in source folder
+    // create a new file
+    fs.writeFileSync(path.join(sourcePath, 'dist/index.new.js'), 'console.log("Hello World!")');
+    // delete a old file
+    fs.rmSync(path.join(sourcePath, 'dist/index.js'));
+    // modify a old file
+    const sourcePackageJsonPath = path.join(sourcePath, 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(sourcePackageJsonPath).toString());
+    const newPackageJsonDescription = 'Test description value';
+    packageJson.description = newPackageJsonDescription;
+
+    // let get the file info of package.json in source folder
+    const sourcePackageJsonStat = fs.statSync(sourcePackageJsonPath);
+
+    fs.writeFileSync(sourcePackageJsonPath, JSON.stringify(packageJson, null, 2), 'utf8');
+
+    // now let run pnpmSyncCopyAsync again
+    await pnpmSyncCopyAsync({
+      pnpmSyncJsonPath,
+      getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
+      forEachAsyncWithConcurrency: Async.forEachAsync,
+      ensureFolderAsync: FileSystem.ensureFolderAsync,
+      logMessageCallback: (): void => {}
+    });
+
+    // ok, now, let's do some verification
+    // 1. for file edit operation
+    // let's read the file info of package.json in destination folder again
+    const newDestinationPackageJsonStat = fs.statSync(destinationPackageJsonPath);
+    // the file ino number should not be changed!
+    expect(sourcePackageJsonStat.ino).toBe(newDestinationPackageJsonStat.ino);
+    expect(sourcePackageJsonStat.ino).toBe(oldDestinationPackageJsonStat.ino);
+    // the actual content should be the new value
+    expect(JSON.parse(fs.readFileSync(destinationPackageJsonPath).toString()).description).toBe(
+      newPackageJsonDescription
+    );
+
+    // 2. the deleted file should not exist
+    expect(fs.existsSync(destinationIndexFilePath)).toBe(false);
+
+    // 3. then new added file should be there
+    expect(fs.existsSync(path.join(destinationPath, 'dist/index.new.js'))).toBe(true);
   });
 });

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
@@ -177,23 +177,22 @@ describe('pnpm-sync-api copy test', () => {
     // let get the file info of package.json in destination folder
     const oldDestinationPackageJsonStat = fs.statSync(destinationPackageJsonPath);
 
-    // now let do some file operations in source folder
+    // now let's do some file operations in source folder
     // create a new file
     fs.writeFileSync(path.join(sourcePath, 'dist/index.new.js'), 'console.log("Hello World!")');
     // delete a old file
     fs.rmSync(path.join(sourcePath, 'dist/index.js'));
-    // modify a old file
+    // modify an existing file
     const sourcePackageJsonPath = path.join(sourcePath, 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(sourcePackageJsonPath).toString());
     const newPackageJsonDescription = 'Test description value';
     packageJson.description = newPackageJsonDescription;
-
-    // let get the file info of package.json in source folder
-    const sourcePackageJsonStat = fs.statSync(sourcePackageJsonPath);
-
     fs.writeFileSync(sourcePackageJsonPath, JSON.stringify(packageJson, null, 2), 'utf8');
 
-    // now let run pnpmSyncCopyAsync again
+    // let get the file info of modified package.json in source folder
+    const sourcePackageJsonStat = fs.statSync(sourcePackageJsonPath);
+
+    // now let's run pnpmSyncCopyAsync again
     await pnpmSyncCopyAsync({
       pnpmSyncJsonPath,
       getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
@@ -206,10 +205,10 @@ describe('pnpm-sync-api copy test', () => {
     // 1. for file edit operation
     // let's read the file info of package.json in destination folder again
     const newDestinationPackageJsonStat = fs.statSync(destinationPackageJsonPath);
-    // the file ino number should not be changed!
+    // Since it is a hard link, the file inode number should not be changed, still the original inode number!
     expect(sourcePackageJsonStat.ino).toBe(newDestinationPackageJsonStat.ino);
     expect(sourcePackageJsonStat.ino).toBe(oldDestinationPackageJsonStat.ino);
-    // the actual content should be the new value
+    // and, the actual content in destination folder should be the new value
     expect(JSON.parse(fs.readFileSync(destinationPackageJsonPath).toString()).description).toBe(
       newPackageJsonDescription
     );

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
@@ -132,5 +132,5 @@ describe('pnpm-sync-api copy test', () => {
         },
       ]
     `);
-  }, 200000);
+  });
 });

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
@@ -37,7 +37,7 @@ describe('pnpm-sync-api prepare test', () => {
     await pnpmSyncPrepareAsync({
       lockfilePath: lockfilePath,
       dotPnpmFolder: dotPnpmFolder,
-      ensureFolder: FileSystem.ensureFolderAsync,
+      ensureFolderAsync: FileSystem.ensureFolderAsync,
       readPnpmLockfile,
       logMessageCallback: (options: ILogMessageCallbackOptions): void => {
         // in this test case, we only care projects under tests/test-fixtures folder
@@ -151,7 +151,7 @@ describe('pnpm-sync-api prepare test', () => {
     await pnpmSyncPrepareAsync({
       lockfilePath: lockfilePath,
       dotPnpmFolder: dotPnpmFolder,
-      ensureFolder: FileSystem.ensureFolderAsync,
+      ensureFolderAsync: FileSystem.ensureFolderAsync,
       readPnpmLockfile,
       logMessageCallback: (options: ILogMessageCallbackOptions): void => {
         // in this test case, we only care projects under tests/test-fixtures/sample-lib1 folder

--- a/tests/test-fixtures/sample-lib2/package.json
+++ b/tests/test-fixtures/sample-lib2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "api-demo-sample-lib2",
   "version": "1.0.0",
-  "description": "",
+  "description": "Test description value",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/tests/test-fixtures/sample-lib2/src/feature1.ts
+++ b/tests/test-fixtures/sample-lib2/src/feature1.ts
@@ -1,0 +1,3 @@
+export function feature1() {
+  return 'This is from feature1';
+}

--- a/tests/test-fixtures/sample-lib2/src/feature2.ts
+++ b/tests/test-fixtures/sample-lib2/src/feature2.ts
@@ -1,0 +1,3 @@
+export function feature2() {
+  return 'This is from feature2';
+}

--- a/tests/test-fixtures/sample-lib2/src/feature3.ts
+++ b/tests/test-fixtures/sample-lib2/src/feature3.ts
@@ -1,0 +1,3 @@
+export function feature3() {
+  return 'This is from feature3';
+}

--- a/tests/test-fixtures/sample-lib2/src/index.ts
+++ b/tests/test-fixtures/sample-lib2/src/index.ts
@@ -1,3 +1,10 @@
+import { feature1 } from './feature1';
+import { feature2 } from './feature2';
+import { feature3 } from './feature3';
+
 export function apiDemoSampleLib2() {
+  feature1();
+  feature2();
+  feature3();
   return 'This is from apiDemoSampleLib2';
 }


### PR DESCRIPTION
### Summary
This PR to add incremental copy for `pnpmSyncCopy` API. 
### Details
In our current implement, for every copy action:
1. Empty the target folder (via `fs.promises.rm`)
2. Copy the files (via `fs.promises.link`) from source folder to target folder

To improve this, instead of copying from scratch every time, we can just copy the changed files to the target folder. That is:
1. Analyze the difference between source folder and target folder. 
2. Copy the added files, replace the changed files, and delete the removed files 

### Performance
Let's do an experiment with a folder that has ~3500 files. 
The copy from scratch will cost around ~700ms. 
The incremental copy will cost around ~70ms - ~770ms (the best case is all files are not changed, the worst case is all files are changed)