### PR TITLE
chore: to prevent an edge case for injected dependency version

### DIFF
--- a/packages/pnpm-sync-lib/package.json
+++ b/packages/pnpm-sync-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync-lib",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "API library for integrating \"pnpm-sync\" with your toolchain",
   "repository": {
     "type": "git",

--- a/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
+++ b/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
@@ -296,7 +296,11 @@ function processDependencies(
     for (const [dependency, specifier] of Object.entries(dependencies)) {
       if (injectedDependencyToVersion.has(dependency)) {
         const specifierToUse: string = typeof specifier === 'string' ? specifier : specifier.version;
-        injectedDependencyToVersion.get(dependency)?.add(specifierToUse);
+
+        // the injected dependency should always start with file protocol
+        if (specifierToUse.startsWith('file:')) {
+          injectedDependencyToVersion.get(dependency)?.add(specifierToUse);
+        }
       }
     }
   }

--- a/packages/pnpm-sync/package.json
+++ b/packages/pnpm-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Recopy injected dependencies whenever a project is rebuilt in your PNPM workspace",
   "keywords": [
     "rush",


### PR DESCRIPTION
## Summary
In some cases, users may mistakenly config the injected install for a dependency. For example, setting the injected install for non workspace level packages. 

This PR is to add a protection on the `pnpm-sync` side, to ignore these wrong configurations. 