### PR TITLE
fix: always inject dependencies from other subspaces

### DIFF
--- a/packages/pnpm-sync-lib/package.json
+++ b/packages/pnpm-sync-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync-lib",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "API library for integrating \"pnpm-sync\" with your toolchain",
   "repository": {
     "type": "git",

--- a/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
+++ b/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
@@ -276,6 +276,7 @@ function getInjectedDependencyToVersion(
       const specifierToUse: string = typeof specifier === 'string' ? specifier : specifier.version;
       // the injected dependency should always start with file protocol
       // and exclude tarball installation
+      // what is the tarball installation, learn more: https://pnpm.io/cli/add#install-from-local-file-system
 
       const tarballSuffix = ['.tar', '.tar.gz', '.tgz'];
       if (

--- a/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
+++ b/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
@@ -128,7 +128,14 @@ export async function pnpmSyncPrepareAsync(options: IPnpmSyncPrepareOptions): Pr
   }
 
   // find injected dependency and all its available versions
-  const injectedDependencyToVersion: Map<string, Set<string>> = getInjectedDependencyToVersion(pnpmLockfile);
+  const injectedDependencyToVersion: Map<string, Set<string>> = new Map();
+  for (const importerItem of Object.values(pnpmLockfile?.importers || {})) {
+    // based on https://pnpm.io/package_json#dependenciesmeta
+    // the injected dependencies could available inside dependencies, optionalDependencies, and devDependencies.
+    getInjectedDependencyToVersion(importerItem?.dependencies, injectedDependencyToVersion);
+    getInjectedDependencyToVersion(importerItem?.devDependencies, injectedDependencyToVersion);
+    getInjectedDependencyToVersion(importerItem?.optionalDependencies, injectedDependencyToVersion);
+  }
 
   // check and process transitive injected dependency
   processTransitiveInjectedDependency(pnpmLockfile, injectedDependencyToVersion);
@@ -260,47 +267,19 @@ export async function pnpmSyncPrepareAsync(options: IPnpmSyncPrepareOptions): Pr
   });
 }
 
-// process dependencies and devDependencies to generate injectedDependencyToFilePath
-function getInjectedDependencyToVersion(pnpmLockfile: ILockfile | undefined): Map<string, Set<string>> {
-  const injectedDependencyToVersion: Map<string, Set<string>> = new Map();
-  for (const importerKey in pnpmLockfile?.importers) {
-    if (!pnpmLockfile?.importers[importerKey]?.dependenciesMeta) {
-      continue;
-    }
-    const dependenciesMeta = pnpmLockfile?.importers[importerKey]?.dependenciesMeta;
-
-    for (const dependency in dependenciesMeta) {
-      if (dependenciesMeta[dependency]?.injected) {
-        if (!injectedDependencyToVersion.has(dependency)) {
-          injectedDependencyToVersion.set(dependency, new Set());
-        }
-      }
-    }
-
-    // based on https://pnpm.io/package_json#dependenciesmeta
-    // the injected dependencies could available inside dependencies, optionalDependencies, and devDependencies.
-    processDependencies(pnpmLockfile?.importers[importerKey]?.dependencies, injectedDependencyToVersion);
-    processDependencies(pnpmLockfile?.importers[importerKey]?.devDependencies, injectedDependencyToVersion);
-    processDependencies(
-      pnpmLockfile?.importers[importerKey]?.optionalDependencies,
-      injectedDependencyToVersion
-    );
-  }
-  return injectedDependencyToVersion;
-}
-function processDependencies(
+function getInjectedDependencyToVersion(
   dependencies: Record<string, IVersionSpecifier> | undefined,
   injectedDependencyToVersion: Map<string, Set<string>>
 ): void {
   if (dependencies) {
     for (const [dependency, specifier] of Object.entries(dependencies)) {
-      if (injectedDependencyToVersion.has(dependency)) {
-        const specifierToUse: string = typeof specifier === 'string' ? specifier : specifier.version;
-
-        // the injected dependency should always start with file protocol
-        if (specifierToUse.startsWith('file:')) {
-          injectedDependencyToVersion.get(dependency)?.add(specifierToUse);
+      const specifierToUse: string = typeof specifier === 'string' ? specifier : specifier.version;
+      // the injected dependency should always start with file protocol
+      if (specifierToUse.startsWith('file:')) {
+        if (!injectedDependencyToVersion.has(dependency)) {
+          injectedDependencyToVersion.set(dependency, new Set());
         }
+        injectedDependencyToVersion.get(dependency)?.add(specifierToUse);
       }
     }
   }

--- a/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
+++ b/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
@@ -275,7 +275,13 @@ function getInjectedDependencyToVersion(
     for (const [dependency, specifier] of Object.entries(dependencies)) {
       const specifierToUse: string = typeof specifier === 'string' ? specifier : specifier.version;
       // the injected dependency should always start with file protocol
-      if (specifierToUse.startsWith('file:')) {
+      // and exclude tarball installation
+
+      const tarballSuffix = ['.tar', '.tar.gz', '.tgz'];
+      if (
+        specifierToUse.startsWith('file:') &&
+        !tarballSuffix.some((suffix) => specifierToUse.endsWith(suffix))
+      ) {
         if (!injectedDependencyToVersion.has(dependency)) {
           injectedDependencyToVersion.set(dependency, new Set());
         }

--- a/packages/pnpm-sync/package.json
+++ b/packages/pnpm-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Recopy injected dependencies whenever a project is rebuilt in your PNPM workspace",
   "keywords": [
     "rush",


### PR DESCRIPTION
### Summary
Fix a issue in `alwaysInjectDependenciesFromOtherSubspaces` logic. 

Before,  we check the injected settings in the `package.json` to tell if a dependency is injected or not. However, in `alwaysInjectDependenciesFromOtherSubspaces` case, user no need to set injected settings in `package.json` for these dependencies. So this check logic is no longer accurate. It will lead a issue that `pnpm-sync.json` is not generated for these dependencies. 

So, now, we check the version representation in `pnpm-lock.yaml` to see if it is started with `file:`, if yes, then it is a injected dependency. 