### PR TITLE
feat: add an identifier for pnpmSyncPrepare

### DIFF
--- a/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
+++ b/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
@@ -61,6 +61,7 @@ export interface IPnpmSyncCopyOptions {
 export interface IPnpmSyncPrepareOptions {
     dotPnpmFolder: string;
     ensureFolderAsync: (folderPath: string) => Promise<void>;
+    identifier?: string;
     lockfilePath: string;
     logMessageCallback: (options: ILogMessageCallbackOptions) => void;
     readPnpmLockfile: (lockfilePath: string, options: {

--- a/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
+++ b/packages/pnpm-sync-lib/etc/pnpm-sync-lib.api.md
@@ -61,7 +61,7 @@ export interface IPnpmSyncCopyOptions {
 export interface IPnpmSyncPrepareOptions {
     dotPnpmFolder: string;
     ensureFolderAsync: (folderPath: string) => Promise<void>;
-    identifier?: string;
+    lockfileId?: string;
     lockfilePath: string;
     logMessageCallback: (options: ILogMessageCallbackOptions) => void;
     readPnpmLockfile: (lockfilePath: string, options: {

--- a/packages/pnpm-sync-lib/package.json
+++ b/packages/pnpm-sync-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync-lib",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "API library for integrating \"pnpm-sync\" with your toolchain",
   "repository": {
     "type": "git",

--- a/packages/pnpm-sync-lib/src/interfaces.ts
+++ b/packages/pnpm-sync-lib/src/interfaces.ts
@@ -14,6 +14,7 @@ export interface IPnpmSyncJson {
 
 export interface ITargetFolder {
   folderPath: string;
+  identifier?: string;
 }
 
 export interface ISyncItem {

--- a/packages/pnpm-sync-lib/src/interfaces.ts
+++ b/packages/pnpm-sync-lib/src/interfaces.ts
@@ -14,7 +14,7 @@ export interface IPnpmSyncJson {
 
 export interface ITargetFolder {
   folderPath: string;
-  identifier?: string;
+  lockfileId?: string;
 }
 
 export interface ISyncItem {

--- a/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
+++ b/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
@@ -31,9 +31,9 @@ export interface IPnpmSyncPrepareOptions {
   dotPnpmFolder: string;
 
   /**
-   * An identifier that can be used to recognize the `pnpm-lock.yaml`
+   * A lockfileId that can be used to recognize the `pnpm-lock.yaml`
    */
-  identifier?: string;
+  lockfileId?: string;
 
   /**
    * Environment-provided API to avoid an NPM dependency.
@@ -69,7 +69,7 @@ export interface IPnpmSyncPrepareOptions {
  * @beta
  */
 export async function pnpmSyncPrepareAsync(options: IPnpmSyncPrepareOptions): Promise<void> {
-  const { identifier, ensureFolderAsync, readPnpmLockfile, logMessageCallback } = options;
+  const { lockfileId, ensureFolderAsync, readPnpmLockfile, logMessageCallback } = options;
   let { lockfilePath, dotPnpmFolder } = options;
 
   // get the pnpm-lock.yaml path
@@ -220,12 +220,12 @@ export async function pnpmSyncPrepareAsync(options: IPnpmSyncPrepareOptions): Pr
 
       const actualPnpmSyncJsonVersion: string = existingPnpmSyncJsonFile?.version;
       if (actualPnpmSyncJsonVersion === expectedPnpmSyncJsonVersion) {
-        // If an identifier is provided
-        // then all entries with this identifier should be deleted
+        // If a lockfileId is provided
+        // then all entries with this lockfileId should be deleted
         // they will be regenerated later
-        if (identifier) {
+        if (lockfileId) {
           const filteredTargetFolders = existingPnpmSyncJsonFile.postbuildInjectedCopy.targetFolders.filter(
-            (targetFolder) => targetFolder?.identifier !== identifier
+            (targetFolder) => targetFolder?.lockfileId !== lockfileId
           );
           existingPnpmSyncJsonFile.postbuildInjectedCopy.targetFolders = filteredTargetFolders;
         }
@@ -262,8 +262,8 @@ export async function pnpmSyncPrepareAsync(options: IPnpmSyncPrepareOptions): Pr
           folderPath: relativePath
         };
 
-        if (identifier) {
-          targetFolderItem.identifier = identifier;
+        if (lockfileId) {
+          targetFolderItem.lockfileId = lockfileId;
         }
 
         pnpmSyncJsonFile.postbuildInjectedCopy.targetFolders.push(targetFolderItem);

--- a/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
+++ b/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
@@ -11,7 +11,8 @@ import {
   LogMessageIdentifier,
   IPnpmSyncJson,
   IVersionSpecifier,
-  ILockfilePackage
+  ILockfilePackage,
+  ITargetFolder
 } from './interfaces';
 import { pnpmSyncGetJsonVersion } from './utilities';
 
@@ -28,6 +29,11 @@ export interface IPnpmSyncPrepareOptions {
    * The path to the PNPM virtual store ("node_modules/.pnpm" folder)
    */
   dotPnpmFolder: string;
+
+  /**
+   * An identifier that can be used to recognize the `pnpm-lock.yaml`
+   */
+  identifier?: string;
 
   /**
    * Environment-provided API to avoid an NPM dependency.
@@ -63,7 +69,7 @@ export interface IPnpmSyncPrepareOptions {
  * @beta
  */
 export async function pnpmSyncPrepareAsync(options: IPnpmSyncPrepareOptions): Promise<void> {
-  const { ensureFolderAsync, readPnpmLockfile, logMessageCallback } = options;
+  const { identifier, ensureFolderAsync, readPnpmLockfile, logMessageCallback } = options;
   let { lockfilePath, dotPnpmFolder } = options;
 
   // get the pnpm-lock.yaml path
@@ -214,6 +220,15 @@ export async function pnpmSyncPrepareAsync(options: IPnpmSyncPrepareOptions): Pr
 
       const actualPnpmSyncJsonVersion: string = existingPnpmSyncJsonFile?.version;
       if (actualPnpmSyncJsonVersion === expectedPnpmSyncJsonVersion) {
+        // If an identifier is provided
+        // then all entries with this identifier should be deleted
+        // they will be regenerated later
+        if (identifier) {
+          const filteredTargetFolders = existingPnpmSyncJsonFile.postbuildInjectedCopy.targetFolders.filter(
+            (targetFolder) => targetFolder?.identifier !== identifier
+          );
+          existingPnpmSyncJsonFile.postbuildInjectedCopy.targetFolders = filteredTargetFolders;
+        }
         pnpmSyncJsonFile = existingPnpmSyncJsonFile;
       } else {
         logMessageCallback({
@@ -243,9 +258,15 @@ export async function pnpmSyncPrepareAsync(options: IPnpmSyncPrepareOptions): Pr
       relativePath = relativePath.split(path.sep).join(path.posix.sep);
 
       if (!existingTargetFolderSet.has(relativePath)) {
-        pnpmSyncJsonFile.postbuildInjectedCopy.targetFolders.push({
+        const targetFolderItem: ITargetFolder = {
           folderPath: relativePath
-        });
+        };
+
+        if (identifier) {
+          targetFolderItem.identifier = identifier;
+        }
+
+        pnpmSyncJsonFile.postbuildInjectedCopy.targetFolders.push(targetFolderItem);
       }
     }
 

--- a/packages/pnpm-sync/package.json
+++ b/packages/pnpm-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Recopy injected dependencies whenever a project is rebuilt in your PNPM workspace",
   "keywords": [
     "rush",

--- a/tests/pnpm-sync-api-test/config/jest.config.json
+++ b/tests/pnpm-sync-api-test/config/jest.config.json
@@ -9,5 +9,8 @@
   "coverageReporters": ["cobertura", "html"],
 
   // Use v8 coverage provider to avoid Babel
-  "coverageProvider": "v8"
+  "coverageProvider": "v8",
+
+  // Let jest test files run one by one
+  "maxWorkers": 1
 }

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
@@ -17,6 +17,21 @@ describe('pnpm-sync-api copy test', () => {
     const lockfilePath = '../../pnpm-lock.yaml';
     const dotPnpmFolder = '../../node_modules/.pnpm';
 
+    const pnpmSyncJsonFolder1 = `../test-fixtures/sample-lib1/node_modules`;
+    const pnpmSyncJsonFolder2 = `../test-fixtures/sample-lib2/node_modules`;
+
+    const pnpmSyncJsonPath1 = `${pnpmSyncJsonFolder1}/.pnpm-sync.json`;
+    const pnpmSyncJsonPath2 = `${pnpmSyncJsonFolder2}/.pnpm-sync.json`;
+
+    // if .pnpm-sync.json already exists, delete it first
+    if (fs.existsSync(pnpmSyncJsonPath1)) {
+      fs.unlinkSync(pnpmSyncJsonPath1);
+    }
+
+    if (fs.existsSync(pnpmSyncJsonPath2)) {
+      fs.unlinkSync(pnpmSyncJsonPath2);
+    }
+
     // generate .pnpm-sync.json file first.
     await pnpmSyncPrepareAsync({
       lockfilePath: lockfilePath,
@@ -25,12 +40,6 @@ describe('pnpm-sync-api copy test', () => {
       readPnpmLockfile,
       logMessageCallback: (): void => {}
     });
-
-    const pnpmSyncJsonFolder1 = `../test-fixtures/sample-lib1/node_modules`;
-    const pnpmSyncJsonFolder2 = `../test-fixtures/sample-lib2/node_modules`;
-
-    const pnpmSyncJsonPath1 = `${pnpmSyncJsonFolder1}/.pnpm-sync.json`;
-    const pnpmSyncJsonPath2 = `${pnpmSyncJsonFolder2}/.pnpm-sync.json`;
 
     const targetFolderPath1 =
       '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib1';

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
@@ -222,17 +222,17 @@ describe('pnpm-sync-api prepare test', () => {
           {
             folderPath:
               '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib1',
-            identifier: 'identifier1'
+            lockfileId: 'identifier1'
           },
           {
             folderPath:
               '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib2',
-            identifier: 'identifier1'
+            lockfileId: 'identifier1'
           },
           {
             folderPath:
               '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib3',
-            identifier: 'identifier2'
+            lockfileId: 'identifier2'
           }
         ]
       }
@@ -244,7 +244,7 @@ describe('pnpm-sync-api prepare test', () => {
     await pnpmSyncPrepareAsync({
       lockfilePath: lockfilePath,
       dotPnpmFolder: dotPnpmFolder,
-      identifier: 'identifier1',
+      lockfileId: 'identifier1',
       ensureFolderAsync: FileSystem.ensureFolderAsync,
       readPnpmLockfile,
       logMessageCallback: (): void => {}
@@ -263,12 +263,12 @@ describe('pnpm-sync-api prepare test', () => {
           {
             folderPath:
               '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib3',
-            identifier: 'identifier2'
+            lockfileId: 'identifier2'
           },
           {
             folderPath:
               '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib1',
-            identifier: 'identifier1'
+            lockfileId: 'identifier1'
           }
         ]
       }

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
@@ -201,4 +201,77 @@ describe('pnpm-sync-api prepare test', () => {
       }
     });
   });
+
+  it('pnpmSyncPrepareAsync should handle identifier (if provided)', async () => {
+    const lockfilePath = '../../pnpm-lock.yaml';
+    const dotPnpmFolder = '../../node_modules/.pnpm';
+
+    const pnpmSyncJsonFolder = `../test-fixtures/sample-lib1/node_modules`;
+    const pnpmSyncJsonPath = `${pnpmSyncJsonFolder}/.pnpm-sync.json`;
+
+    if (!fs.existsSync(pnpmSyncJsonFolder)) {
+      await FileSystem.ensureFolderAsync(pnpmSyncJsonFolder);
+    }
+
+    // create an .pnpm-sync.json with some identifiers
+    const pnpmSyncJsonFile = {
+      version: pnpmSyncLibVersion,
+      postbuildInjectedCopy: {
+        sourceFolder: '..',
+        targetFolders: [
+          {
+            folderPath:
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib1',
+            identifier: 'identifier1'
+          },
+          {
+            folderPath:
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib2',
+            identifier: 'identifier1'
+          },
+          {
+            folderPath:
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib3',
+            identifier: 'identifier2'
+          }
+        ]
+      }
+    };
+
+    // write .pnpm-sync.json
+    await fs.promises.writeFile(pnpmSyncJsonPath, JSON.stringify(pnpmSyncJsonFile, null, 2));
+
+    await pnpmSyncPrepareAsync({
+      lockfilePath: lockfilePath,
+      dotPnpmFolder: dotPnpmFolder,
+      identifier: 'identifier1',
+      ensureFolderAsync: FileSystem.ensureFolderAsync,
+      readPnpmLockfile,
+      logMessageCallback: (): void => {}
+    });
+
+    // now, read .pnpm-sync.json and check the fields
+    expect(fs.existsSync(pnpmSyncJsonPath)).toBe(true);
+
+    // the folderPath with identifier1 should be regenerated
+    // the folderPath with identifier2 should keep as it is
+    expect(JSON.parse(fs.readFileSync(pnpmSyncJsonPath).toString())).toEqual({
+      version: pnpmSyncLibVersion,
+      postbuildInjectedCopy: {
+        sourceFolder: '..',
+        targetFolders: [
+          {
+            folderPath:
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib3',
+            identifier: 'identifier2'
+          },
+          {
+            folderPath:
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib1',
+            identifier: 'identifier1'
+          }
+        ]
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary
 Support an optional parameter `lockfileId` when calling the `pnpmSyncPrepareAsync` API. 
The purpose of this parameter is let `pnpm-sync` to recognize the entries in the `.pnpm-config.json` file, so that the `pnpm-sync` can update these entries correctly, also be able to remove invalid entires

## Details
When calling the `pnpmSyncPrepareAsync` API,  how does `pnpm-sync` know which entries need to be update in the `.pnpm-config.json`? Especially in a large Monorepo with Rush subspace feature enabled where there could have tens of `pnpm-lock.yaml` files. 

Previously, when generating the `.pnpm-config.json`, `pnpm-sync` read the existing entries, only append new unique entires there. This is to ensure the tool doesn't delete entries where could belong to other `pnpm-lock.yaml`. But, it has a drawback where, since it does not delete any entries, it is possible, in your local development, there could be some invalid entries in the  `.pnpm-config.json` due to frequently `pnpm-lock.yaml` changes. It might cause issue as time goes by, and when it happens, you will need to manually delete `.pnpm-config.json` file or `node_modules` to regenerate them. It brings inconvenience.

In this PR, we add a optional parameter `identifier` when calling the `pnpmSyncPrepareAsync` API. So that, the `pnpm-sync` could recognize the `pnpm-lock.yaml` file it processed, then it able to delete the invalid entries in the `.pnpm-config.json`  to avoid unnecessary or invalid sync actions in the later steps. 