### PR TITLE
feat: improve error handling when failed to load pnpm-sync.json

### DIFF
--- a/packages/pnpm-sync-lib/package.json
+++ b/packages/pnpm-sync-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync-lib",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "API library for integrating \"pnpm-sync\" with your toolchain",
   "repository": {
     "type": "git",

--- a/packages/pnpm-sync/package.json
+++ b/packages/pnpm-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Recopy injected dependencies whenever a project is rebuilt in your PNPM workspace",
   "keywords": [
     "rush",


### PR DESCRIPTION
### Summary

Improve error handling when loading the existing `.pnpm-sync.json`

### Detail

There a edge case when writing `.pnpm-sync.json` fails. This may leave a empty `.pnpm-sync.json` file. `pnpm-sync` complains about invalid JSON when loading the current `.pnpm-sync.json` file.

Actual:
<img width="504" alt="image" src="https://github.com/tiktok/pnpm-sync/assets/16147702/f3b56c45-9d76-4656-8554-81915b32cdee">

<img width="700" alt="image" src="https://github.com/tiktok/pnpm-sync/assets/16147702/60c231ba-5e4b-4417-ae73-44293fc5a72c">

Expected: No error
