### PR TITLE
fix: ignore node_modules in .pnpm folder

### DIFF
--- a/packages/pnpm-sync-lib/package.json
+++ b/packages/pnpm-sync-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync-lib",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "API library for integrating \"pnpm-sync\" with your toolchain",
   "repository": {
     "type": "git",

--- a/packages/pnpm-sync-lib/src/utilities.ts
+++ b/packages/pnpm-sync-lib/src/utilities.ts
@@ -22,7 +22,9 @@ async function getFilesInDirectoryHelper(directory: string, returnFileList: ISyn
 
   for (const item of itemList) {
     const absolutePath: string = path.join(directory, item.name);
-    // ignore node_modules folder in the pnpm-store location
+    // when PNPM install injected dependencies
+    // it will create necessary node_modules/.bin folder in PNPM store
+    // so we need to ignore node_modules folder in the pnpm-store location
     if (item.isDirectory() && item.name !== 'node_modules') {
       await getFilesInDirectoryHelper(absolutePath, returnFileList);
     }

--- a/packages/pnpm-sync-lib/src/utilities.ts
+++ b/packages/pnpm-sync-lib/src/utilities.ts
@@ -22,7 +22,8 @@ async function getFilesInDirectoryHelper(directory: string, returnFileList: ISyn
 
   for (const item of itemList) {
     const absolutePath: string = path.join(directory, item.name);
-    if (item.isDirectory()) {
+    // ignore node_modules folder in the pnpm-store location
+    if (item.isDirectory() && item.name !== 'node_modules') {
       await getFilesInDirectoryHelper(absolutePath, returnFileList);
     }
 

--- a/packages/pnpm-sync/package.json
+++ b/packages/pnpm-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Recopy injected dependencies whenever a project is rebuilt in your PNPM workspace",
   "keywords": [
     "rush",

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
@@ -228,4 +228,38 @@ describe('pnpm-sync-api copy test', () => {
     // 3. then new added file should be there
     expect(fs.existsSync(path.join(destinationPath, 'dist/index.new.js'))).toBe(true);
   });
+
+  it('pnpmSyncCopyAsync should not delete node_modules folder in .pnpm folder', async () => {
+    const pnpmSyncJsonFolder = `../test-fixtures/sample-lib2/node_modules`;
+    const pnpmSyncJsonPath = `${pnpmSyncJsonFolder}/.pnpm-sync.json`;
+
+    const targetFolderPath =
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/api-demo-sample-lib2';
+
+    const destinationPath = path.resolve(pnpmSyncJsonFolder, targetFolderPath);
+
+    // let fake a node_modules and add some files
+    // create node_modules folder
+    fs.mkdirSync(path.join(destinationPath, 'node_modules'));
+    // create .bin folder
+    fs.mkdirSync(path.join(destinationPath, 'node_modules/.bin'));
+    // create a test file
+    const testBinFileInDestinationPath: string = path.join(destinationPath, 'node_modules/.bin/test.js');
+    fs.writeFileSync(testBinFileInDestinationPath, 'console.log("Hello World in .bin!")');
+
+    // let's do copy action first
+    await pnpmSyncCopyAsync({
+      pnpmSyncJsonPath,
+      getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
+      forEachAsyncWithConcurrency: Async.forEachAsync,
+      ensureFolderAsync: FileSystem.ensureFolderAsync,
+      logMessageCallback: (): void => {}
+    });
+
+    // after copy action, the destination folder should exists
+    expect(fs.existsSync(destinationPath)).toBe(true);
+
+    // and the test file should be there
+    expect(fs.existsSync(testBinFileInDestinationPath)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
In some cases, when PNPM install injected dependencies, it will create necessary `node_modules/.bin` folder in PNPM store.
We will need to keep it as it is as delete them is not a safe action for now. 