### PR TITLE
fix: rename test pacakges

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,7 +196,7 @@ importers:
 
   tests/test-fixtures/sample-app1:
     dependencies:
-      '@tiktok-frontend/api-demo-sample-lib1':
+      '@tiktok-service/api-demo-sample-lib1':
         specifier: workspace:*
         version: file:tests/test-fixtures/sample-lib1(react@17.0.2)
       react:
@@ -210,12 +210,12 @@ importers:
         specifier: ^5.2.2
         version: 5.3.3
     dependenciesMeta:
-      '@tiktok-frontend/api-demo-sample-lib1':
+      '@tiktok-service/api-demo-sample-lib1':
         injected: true
 
   tests/test-fixtures/sample-lib1:
     dependencies:
-      '@tiktok-frontend/api-demo-sample-lib2':
+      '@tiktok-service/api-demo-sample-lib2':
         specifier: 'workspace: *'
         version: file:tests/test-fixtures/sample-lib2(react@17.0.2)
     devDependencies:
@@ -229,7 +229,7 @@ importers:
         specifier: ^5.2.2
         version: 5.3.3
     dependenciesMeta:
-      '@tiktok-frontend/api-demo-sample-lib2':
+      '@tiktok-service/api-demo-sample-lib2':
         injected: true
 
   tests/test-fixtures/sample-lib2:
@@ -4979,18 +4979,18 @@ packages:
   file:tests/test-fixtures/sample-lib1(react@17.0.2):
     resolution: {directory: tests/test-fixtures/sample-lib1, type: directory}
     id: file:tests/test-fixtures/sample-lib1
-    name: '@tiktok-frontend/api-demo-sample-lib1'
+    name: '@tiktok-service/api-demo-sample-lib1'
     peerDependencies:
       react: 17 || 18
     dependencies:
-      '@tiktok-frontend/api-demo-sample-lib2': file:tests/test-fixtures/sample-lib2(react@17.0.2)
+      '@tiktok-service/api-demo-sample-lib2': file:tests/test-fixtures/sample-lib2(react@17.0.2)
       react: 17.0.2
     dev: false
 
   file:tests/test-fixtures/sample-lib2(react@17.0.2):
     resolution: {directory: tests/test-fixtures/sample-lib2, type: directory}
     id: file:tests/test-fixtures/sample-lib2
-    name: '@tiktok-frontend/api-demo-sample-lib2'
+    name: '@tiktok-service/api-demo-sample-lib2'
     peerDependencies:
       react: 17 || 18
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,7 +196,7 @@ importers:
 
   tests/test-fixtures/sample-app1:
     dependencies:
-      api-demo-sample-lib1:
+      '@tiktok-arch/api-demo-sample-lib1':
         specifier: workspace:*
         version: file:tests/test-fixtures/sample-lib1(react@17.0.2)
       react:
@@ -210,12 +210,12 @@ importers:
         specifier: ^5.2.2
         version: 5.3.3
     dependenciesMeta:
-      api-demo-sample-lib1:
+      '@tiktok-arch/api-demo-sample-lib1':
         injected: true
 
   tests/test-fixtures/sample-lib1:
     dependencies:
-      api-demo-sample-lib2:
+      '@tiktok-arch/api-demo-sample-lib2':
         specifier: 'workspace: *'
         version: file:tests/test-fixtures/sample-lib2(react@17.0.2)
     devDependencies:
@@ -229,7 +229,7 @@ importers:
         specifier: ^5.2.2
         version: 5.3.3
     dependenciesMeta:
-      api-demo-sample-lib2:
+      '@tiktok-arch/api-demo-sample-lib2':
         injected: true
 
   tests/test-fixtures/sample-lib2:
@@ -4979,18 +4979,18 @@ packages:
   file:tests/test-fixtures/sample-lib1(react@17.0.2):
     resolution: {directory: tests/test-fixtures/sample-lib1, type: directory}
     id: file:tests/test-fixtures/sample-lib1
-    name: api-demo-sample-lib1
+    name: '@tiktok-arch/api-demo-sample-lib1'
     peerDependencies:
       react: 17 || 18
     dependencies:
-      api-demo-sample-lib2: file:tests/test-fixtures/sample-lib2(react@17.0.2)
+      '@tiktok-arch/api-demo-sample-lib2': file:tests/test-fixtures/sample-lib2(react@17.0.2)
       react: 17.0.2
     dev: false
 
   file:tests/test-fixtures/sample-lib2(react@17.0.2):
     resolution: {directory: tests/test-fixtures/sample-lib2, type: directory}
     id: file:tests/test-fixtures/sample-lib2
-    name: api-demo-sample-lib2
+    name: '@tiktok-arch/api-demo-sample-lib2'
     peerDependencies:
       react: 17 || 18
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,7 +196,7 @@ importers:
 
   tests/test-fixtures/sample-app1:
     dependencies:
-      '@tiktok-arch/api-demo-sample-lib1':
+      '@tiktok-frontend/api-demo-sample-lib1':
         specifier: workspace:*
         version: file:tests/test-fixtures/sample-lib1(react@17.0.2)
       react:
@@ -210,12 +210,12 @@ importers:
         specifier: ^5.2.2
         version: 5.3.3
     dependenciesMeta:
-      '@tiktok-arch/api-demo-sample-lib1':
+      '@tiktok-frontend/api-demo-sample-lib1':
         injected: true
 
   tests/test-fixtures/sample-lib1:
     dependencies:
-      '@tiktok-arch/api-demo-sample-lib2':
+      '@tiktok-frontend/api-demo-sample-lib2':
         specifier: 'workspace: *'
         version: file:tests/test-fixtures/sample-lib2(react@17.0.2)
     devDependencies:
@@ -229,7 +229,7 @@ importers:
         specifier: ^5.2.2
         version: 5.3.3
     dependenciesMeta:
-      '@tiktok-arch/api-demo-sample-lib2':
+      '@tiktok-frontend/api-demo-sample-lib2':
         injected: true
 
   tests/test-fixtures/sample-lib2:
@@ -4979,18 +4979,18 @@ packages:
   file:tests/test-fixtures/sample-lib1(react@17.0.2):
     resolution: {directory: tests/test-fixtures/sample-lib1, type: directory}
     id: file:tests/test-fixtures/sample-lib1
-    name: '@tiktok-arch/api-demo-sample-lib1'
+    name: '@tiktok-frontend/api-demo-sample-lib1'
     peerDependencies:
       react: 17 || 18
     dependencies:
-      '@tiktok-arch/api-demo-sample-lib2': file:tests/test-fixtures/sample-lib2(react@17.0.2)
+      '@tiktok-frontend/api-demo-sample-lib2': file:tests/test-fixtures/sample-lib2(react@17.0.2)
       react: 17.0.2
     dev: false
 
   file:tests/test-fixtures/sample-lib2(react@17.0.2):
     resolution: {directory: tests/test-fixtures/sample-lib2, type: directory}
     id: file:tests/test-fixtures/sample-lib2
-    name: '@tiktok-arch/api-demo-sample-lib2'
+    name: '@tiktok-frontend/api-demo-sample-lib2'
     peerDependencies:
       react: 17 || 18
     dependencies:

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
@@ -42,9 +42,9 @@ describe('pnpm-sync-api copy test', () => {
     });
 
     const targetFolderPath1 =
-      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib1';
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-service/api-demo-sample-lib1';
     const targetFolderPath2 =
-      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib2';
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-service/api-demo-sample-lib2';
 
     // make sure .pnpm-sync.json exists
     expect(fs.existsSync(pnpmSyncJsonPath1)).toBe(true);
@@ -79,7 +79,7 @@ describe('pnpm-sync-api copy test', () => {
     const pnpmSyncJsonPath = `${pnpmSyncJsonFolder}/.pnpm-sync.json`;
 
     const targetFolderPath =
-      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib1';
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-service/api-demo-sample-lib1';
     const pnpmSyncJsonFile = JSON.parse(fs.readFileSync(pnpmSyncJsonPath).toString());
 
     // set a outdated version
@@ -159,7 +159,7 @@ describe('pnpm-sync-api copy test', () => {
     const pnpmSyncJsonPath = `${pnpmSyncJsonFolder}/.pnpm-sync.json`;
 
     const targetFolderPath =
-      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib2';
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-service/api-demo-sample-lib2';
 
     const destinationPath = path.resolve(pnpmSyncJsonFolder, targetFolderPath);
     const sourcePath = '../test-fixtures/sample-lib2';
@@ -234,7 +234,7 @@ describe('pnpm-sync-api copy test', () => {
     const pnpmSyncJsonPath = `${pnpmSyncJsonFolder}/.pnpm-sync.json`;
 
     const targetFolderPath =
-      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib2';
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-service/api-demo-sample-lib2';
 
     const destinationPath = path.resolve(pnpmSyncJsonFolder, targetFolderPath);
 

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
@@ -42,9 +42,9 @@ describe('pnpm-sync-api copy test', () => {
     });
 
     const targetFolderPath1 =
-      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib1';
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib1';
     const targetFolderPath2 =
-      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/api-demo-sample-lib2';
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib2';
 
     // make sure .pnpm-sync.json exists
     expect(fs.existsSync(pnpmSyncJsonPath1)).toBe(true);
@@ -79,7 +79,7 @@ describe('pnpm-sync-api copy test', () => {
     const pnpmSyncJsonPath = `${pnpmSyncJsonFolder}/.pnpm-sync.json`;
 
     const targetFolderPath =
-      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib1';
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib1';
     const pnpmSyncJsonFile = JSON.parse(fs.readFileSync(pnpmSyncJsonPath).toString());
 
     // set a outdated version
@@ -159,7 +159,7 @@ describe('pnpm-sync-api copy test', () => {
     const pnpmSyncJsonPath = `${pnpmSyncJsonFolder}/.pnpm-sync.json`;
 
     const targetFolderPath =
-      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/api-demo-sample-lib2';
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib2';
 
     const destinationPath = path.resolve(pnpmSyncJsonFolder, targetFolderPath);
     const sourcePath = '../test-fixtures/sample-lib2';
@@ -234,7 +234,7 @@ describe('pnpm-sync-api copy test', () => {
     const pnpmSyncJsonPath = `${pnpmSyncJsonFolder}/.pnpm-sync.json`;
 
     const targetFolderPath =
-      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/api-demo-sample-lib2';
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib2';
 
     const destinationPath = path.resolve(pnpmSyncJsonFolder, targetFolderPath);
 

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncCopy.test.ts
@@ -42,9 +42,9 @@ describe('pnpm-sync-api copy test', () => {
     });
 
     const targetFolderPath1 =
-      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib1';
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib1';
     const targetFolderPath2 =
-      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib2';
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib2';
 
     // make sure .pnpm-sync.json exists
     expect(fs.existsSync(pnpmSyncJsonPath1)).toBe(true);
@@ -79,7 +79,7 @@ describe('pnpm-sync-api copy test', () => {
     const pnpmSyncJsonPath = `${pnpmSyncJsonFolder}/.pnpm-sync.json`;
 
     const targetFolderPath =
-      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib1';
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib1';
     const pnpmSyncJsonFile = JSON.parse(fs.readFileSync(pnpmSyncJsonPath).toString());
 
     // set a outdated version
@@ -159,7 +159,7 @@ describe('pnpm-sync-api copy test', () => {
     const pnpmSyncJsonPath = `${pnpmSyncJsonFolder}/.pnpm-sync.json`;
 
     const targetFolderPath =
-      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib2';
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib2';
 
     const destinationPath = path.resolve(pnpmSyncJsonFolder, targetFolderPath);
     const sourcePath = '../test-fixtures/sample-lib2';
@@ -234,7 +234,7 @@ describe('pnpm-sync-api copy test', () => {
     const pnpmSyncJsonPath = `${pnpmSyncJsonFolder}/.pnpm-sync.json`;
 
     const targetFolderPath =
-      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib2';
+      '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib2';
 
     const destinationPath = path.resolve(pnpmSyncJsonFolder, targetFolderPath);
 

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
@@ -103,7 +103,7 @@ describe('pnpm-sync-api prepare test', () => {
         targetFolders: [
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib1'
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-service/api-demo-sample-lib1'
           }
         ]
       }
@@ -116,7 +116,7 @@ describe('pnpm-sync-api prepare test', () => {
         targetFolders: [
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib2'
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-service/api-demo-sample-lib2'
           }
         ]
       }
@@ -195,7 +195,7 @@ describe('pnpm-sync-api prepare test', () => {
         targetFolders: [
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib1'
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-service/api-demo-sample-lib1'
           }
         ]
       }
@@ -221,17 +221,17 @@ describe('pnpm-sync-api prepare test', () => {
         targetFolders: [
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib1',
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-service/api-demo-sample-lib1',
             lockfileId: 'identifier1'
           },
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib2',
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-service/api-demo-sample-lib2',
             lockfileId: 'identifier1'
           },
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib3',
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-service/api-demo-sample-lib3',
             lockfileId: 'identifier2'
           }
         ]
@@ -262,12 +262,12 @@ describe('pnpm-sync-api prepare test', () => {
         targetFolders: [
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib3',
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-service/api-demo-sample-lib3',
             lockfileId: 'identifier2'
           },
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib1',
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-service/api-demo-sample-lib1',
             lockfileId: 'identifier1'
           }
         ]

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
@@ -103,7 +103,7 @@ describe('pnpm-sync-api prepare test', () => {
         targetFolders: [
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib1'
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib1'
           }
         ]
       }
@@ -116,7 +116,7 @@ describe('pnpm-sync-api prepare test', () => {
         targetFolders: [
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib2'
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib2'
           }
         ]
       }
@@ -195,7 +195,7 @@ describe('pnpm-sync-api prepare test', () => {
         targetFolders: [
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib1'
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib1'
           }
         ]
       }
@@ -221,17 +221,17 @@ describe('pnpm-sync-api prepare test', () => {
         targetFolders: [
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib1',
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib1',
             lockfileId: 'identifier1'
           },
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib2',
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib2',
             lockfileId: 'identifier1'
           },
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib3',
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib3',
             lockfileId: 'identifier2'
           }
         ]
@@ -262,12 +262,12 @@ describe('pnpm-sync-api prepare test', () => {
         targetFolders: [
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib3',
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib3',
             lockfileId: 'identifier2'
           },
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib1',
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-frontend/api-demo-sample-lib1',
             lockfileId: 'identifier1'
           }
         ]

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
@@ -103,7 +103,7 @@ describe('pnpm-sync-api prepare test', () => {
         targetFolders: [
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib1'
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib1'
           }
         ]
       }
@@ -116,7 +116,7 @@ describe('pnpm-sync-api prepare test', () => {
         targetFolders: [
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/api-demo-sample-lib2'
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib2_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib2'
           }
         ]
       }
@@ -195,7 +195,7 @@ describe('pnpm-sync-api prepare test', () => {
         targetFolders: [
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib1'
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib1'
           }
         ]
       }
@@ -221,17 +221,17 @@ describe('pnpm-sync-api prepare test', () => {
         targetFolders: [
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib1',
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib1',
             lockfileId: 'identifier1'
           },
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib2',
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib2',
             lockfileId: 'identifier1'
           },
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib3',
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib3',
             lockfileId: 'identifier2'
           }
         ]
@@ -262,12 +262,12 @@ describe('pnpm-sync-api prepare test', () => {
         targetFolders: [
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib3',
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib3',
             lockfileId: 'identifier2'
           },
           {
             folderPath:
-              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/api-demo-sample-lib1',
+              '../../../../node_modules/.pnpm/file+tests+test-fixtures+sample-lib1_react@17.0.2/node_modules/@tiktok-arch/api-demo-sample-lib1',
             lockfileId: 'identifier1'
           }
         ]

--- a/tests/test-fixtures/sample-app1/package.json
+++ b/tests/test-fixtures/sample-app1/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tiktok-frontend/api-demo-sample-app1",
+  "name": "@tiktok-service/api-demo-sample-app1",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
@@ -10,11 +10,11 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@tiktok-frontend/api-demo-sample-lib1": "workspace:*",
+    "@tiktok-service/api-demo-sample-lib1": "workspace:*",
     "react": "~17.0.0"
   },
   "dependenciesMeta": {
-    "@tiktok-frontend/api-demo-sample-lib1": {
+    "@tiktok-service/api-demo-sample-lib1": {
       "injected": true
     }
   },

--- a/tests/test-fixtures/sample-app1/package.json
+++ b/tests/test-fixtures/sample-app1/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "api-demo-sample-app1",
+  "name": "@tiktok-arch/api-demo-sample-app1",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
@@ -10,11 +10,11 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "api-demo-sample-lib1": "workspace:*",
+    "@tiktok-arch/api-demo-sample-lib1": "workspace:*",
     "react": "~17.0.0"
   },
   "dependenciesMeta": {
-    "api-demo-sample-lib1": {
+    "@tiktok-arch/api-demo-sample-lib1": {
       "injected": true
     }
   },

--- a/tests/test-fixtures/sample-app1/package.json
+++ b/tests/test-fixtures/sample-app1/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tiktok-arch/api-demo-sample-app1",
+  "name": "@tiktok-frontend/api-demo-sample-app1",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
@@ -10,11 +10,11 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@tiktok-arch/api-demo-sample-lib1": "workspace:*",
+    "@tiktok-frontend/api-demo-sample-lib1": "workspace:*",
     "react": "~17.0.0"
   },
   "dependenciesMeta": {
-    "@tiktok-arch/api-demo-sample-lib1": {
+    "@tiktok-frontend/api-demo-sample-lib1": {
       "injected": true
     }
   },

--- a/tests/test-fixtures/sample-lib1/package.json
+++ b/tests/test-fixtures/sample-lib1/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tiktok-arch/api-demo-sample-lib1",
+  "name": "@tiktok-frontend/api-demo-sample-lib1",
   "version": "1.0.0",
   "description": "",
   "main": "dist/index.js",
@@ -15,10 +15,10 @@
     "react": "17 || 18"
   },
   "dependencies": {
-    "@tiktok-arch/api-demo-sample-lib2": "workspace: *"
+    "@tiktok-frontend/api-demo-sample-lib2": "workspace: *"
   },
   "dependenciesMeta": {
-    "@tiktok-arch/api-demo-sample-lib2": {
+    "@tiktok-frontend/api-demo-sample-lib2": {
       "injected": true
     }
   },

--- a/tests/test-fixtures/sample-lib1/package.json
+++ b/tests/test-fixtures/sample-lib1/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tiktok-frontend/api-demo-sample-lib1",
+  "name": "@tiktok-service/api-demo-sample-lib1",
   "version": "1.0.0",
   "description": "",
   "main": "dist/index.js",
@@ -15,10 +15,10 @@
     "react": "17 || 18"
   },
   "dependencies": {
-    "@tiktok-frontend/api-demo-sample-lib2": "workspace: *"
+    "@tiktok-service/api-demo-sample-lib2": "workspace: *"
   },
   "dependenciesMeta": {
-    "@tiktok-frontend/api-demo-sample-lib2": {
+    "@tiktok-service/api-demo-sample-lib2": {
       "injected": true
     }
   },

--- a/tests/test-fixtures/sample-lib1/package.json
+++ b/tests/test-fixtures/sample-lib1/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "api-demo-sample-lib1",
+  "name": "@tiktok-arch/api-demo-sample-lib1",
   "version": "1.0.0",
   "description": "",
   "main": "dist/index.js",
@@ -15,10 +15,10 @@
     "react": "17 || 18"
   },
   "dependencies": {
-    "api-demo-sample-lib2": "workspace: *"
+    "@tiktok-arch/api-demo-sample-lib2": "workspace: *"
   },
   "dependenciesMeta": {
-    "api-demo-sample-lib2": {
+    "@tiktok-arch/api-demo-sample-lib2": {
       "injected": true
     }
   },

--- a/tests/test-fixtures/sample-lib2/package.json
+++ b/tests/test-fixtures/sample-lib2/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tiktok-arch/api-demo-sample-lib2",
+  "name": "@tiktok-frontend/api-demo-sample-lib2",
   "version": "1.0.0",
   "description": "Test description value",
   "main": "dist/index.js",

--- a/tests/test-fixtures/sample-lib2/package.json
+++ b/tests/test-fixtures/sample-lib2/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tiktok-frontend/api-demo-sample-lib2",
+  "name": "@tiktok-service/api-demo-sample-lib2",
   "version": "1.0.0",
   "description": "Test description value",
   "main": "dist/index.js",

--- a/tests/test-fixtures/sample-lib2/package.json
+++ b/tests/test-fixtures/sample-lib2/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "api-demo-sample-lib2",
+  "name": "@tiktok-arch/api-demo-sample-lib2",
   "version": "1.0.0",
   "description": "Test description value",
   "main": "dist/index.js",


### PR DESCRIPTION
Rename some test packages to avoid to be same as the public npm packages.