### PR TITLE
Fix pnpm version check logic.

### DIFF
--- a/packages/pnpm-sync-lib/package.json
+++ b/packages/pnpm-sync-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync-lib",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "API library for integrating \"pnpm-sync\" with your toolchain",
   "repository": {
     "type": "git",

--- a/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
+++ b/packages/pnpm-sync-lib/src/pnpmSyncPrepare.ts
@@ -219,8 +219,8 @@ export async function pnpmSyncPrepareAsync(options: IPnpmSyncPrepareOptions): Pr
   const pnpmModulesYaml = YAML.parse(fs.readFileSync(`${pnpmModulesYamlPath}/.modules.yaml`, 'utf8'));
   const pnpmVersion: string | undefined = pnpmModulesYaml?.packageManager?.split('@')[1];
 
-  // currently, only support pnpm v8
-  if (!pnpmVersion || !(pnpmVersion.startsWith('8') || !pnpmVersion.startsWith('9'))) {
+  // currently, only support pnpm v8 and v9
+  if (!pnpmVersion || !(pnpmVersion.startsWith('8') || pnpmVersion.startsWith('9'))) {
     logMessageCallback({
       message: `The pnpm version is not supported; pnpm-sync requires pnpm version 8.x, 9.x`,
       messageKind: LogMessageKind.ERROR,
@@ -238,12 +238,12 @@ export async function pnpmSyncPrepareAsync(options: IPnpmSyncPrepareOptions): Pr
     ignoreIncompatible: true
   });
 
-  // currently, only support lockfileVersion 6.x, which is pnpm v8
+  // currently, only support lockfileVersion 6.x, which is pnpm v8 and lockfileVersion 9.x, which is pnpm v9
   const lockfileVersion: string | undefined = pnpmLockfile?.lockfileVersion.toString();
   if (
     !pnpmLockfile ||
     !lockfileVersion ||
-    !(lockfileVersion.startsWith('6') || !lockfileVersion.startsWith('9'))
+    !(lockfileVersion.startsWith('6') || lockfileVersion.startsWith('9'))
   ) {
     logMessageCallback({
       message: `The pnpm-lock.yaml format is not supported; pnpm-sync requires lockfile version 6, 9`,

--- a/packages/pnpm-sync/package.json
+++ b/packages/pnpm-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-sync",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Recopy injected dependencies whenever a project is rebuilt in your PNPM workspace",
   "keywords": [
     "rush",

--- a/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
+++ b/tests/pnpm-sync-api-test/src/test/pnpmSyncPrepare.test.ts
@@ -176,7 +176,7 @@ Array [
   Object {
     "details": Object {
       "actualVersion": "incompatible-version",
-      "expectedVersion": "0.3.1",
+      "expectedVersion": "0.3.2",
       "messageIdentifier": "prepare-replacing-file",
       "pnpmSyncJsonPath": "<root>/pnpm-sync/tests/test-fixtures/sample-lib1/node_modules/.pnpm-sync.json",
       "sourceProjectFolder": "<root>/pnpm-sync/tests/test-fixtures/sample-lib1",


### PR DESCRIPTION
I tested upgrading `pnpm-sync-lib` on https://github.com/microsoft/rushstack/pull/5247. After making the changes in this branch, I'm still getting this error:

```
>node /Users/ianc/code/rushstack5/libraries/rush-lib/lib/start --debug update

Rush Multi-Project Build Tool 5.153.2 (unmanaged) - https://rushjs.io
Node.js version is 22.12.0 (LTS)


Starting "rush update"
Installing for subspace: build-tests-subspace
Checking Git policy for this repository.


Found files in the "common/git-hooks" folder.
Successfully installed these Git hook scripts: pre-commit

Trying to acquire lock for pnpm-9.15.9
Acquired lock for pnpm-9.15.9
Found pnpm version 9.15.9 in /Users/ianc/.rush/node-v22.12.0/pnpm-9.15.9

Symlinking "/Users/ianc/code/rushstack2/common/temp/pnpm-local"
  --> "/Users/ianc/.rush/node-v22.12.0/pnpm-9.15.9"
Transforming /Users/ianc/code/rushstack2/common/config/subspaces/build-tests-subspace/.npmrc
  --> "/Users/ianc/code/rushstack2/common/temp/build-tests-subspace/.npmrc"

Updating workspace files in /Users/ianc/code/rushstack2/common/temp/build-tests-subspace
Total amount of time spent to hash related package.json files in the injected installation case: 0.42 seconds
Copying "/Users/ianc/code/rushstack2/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml"
  --> "/Users/ianc/code/rushstack2/common/temp/build-tests-subspace/pnpm-lock.yaml"
Copying "/Users/ianc/code/rushstack2/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml"
  --> "/Users/ianc/code/rushstack2/common/temp/build-tests-subspace/pnpm-lock-preinstall.yaml"

Checking installation in "/Users/ianc/code/rushstack2/common/temp/build-tests-subspace"

Skipping package registry setup because packageRegistry.enabled=false
Running "pnpm install" in /Users/ianc/code/rushstack2/common/temp/build-tests-subspace


Invoking package manager: /Users/ianc/.rush/node-v22.12.0/pnpm-9.15.9/node_modules/pnpm/bin/pnpm.cjs install --store /Users/ianc/code/rushstack2/common/temp/pnpm-store --config.cacheDir=/Users/ianc/code/rushstack2/common/temp/pnpm-store --config.stateDir=/Users/ianc/code/rushstack2/common/temp/pnpm-store --prefer-frozen-lockfile --strict-peer-dependencies --config.auto-install-peers=false --config.resolutionMode=highest --config.ignoreCompatibilityDb --recursive --link-workspace-packages false --reporter default

Scope: all 5 workspace projects
.../build-tests-subspace/rush-lib-test   |  WARN  deprecated eslint@8.57.1
 WARN  10 deprecated subdependencies found: @humanwhocodes/config-array@0.13.0, @humanwhocodes/object-schema@2.0.3, debuglog@1.0.1, glob@7.2.3, inflight@1.0.6, osenv@0.1.5, read-package-json@2.1.2, read-package-tree@5.1.6, readdir-scoped-modules@1.1.0, rimraf@3.0.2
.                                        |  +32 +++
Progress: resolved 836, reused 836, downloaded 0, added 32, done
Done in 2.5s using pnpm v9.15.9

pnpm-sync: Starting operation...
pnpm-sync: pnpm-lock.yaml file path: /Users/ianc/code/rushstack2/common/temp/build-tests-subspace/pnpm-lock.yaml
pnpm-sync: .pnpm folder path: /Users/ianc/code/rushstack2/common/temp/build-tests-subspace/node_modules/.pnpm
pnpm-sync: Writing /Users/ianc/code/rushstack2/libraries/rush-lib/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/libraries/terminal/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/apps/heft/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/rigs/local-node-rig/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/libraries/rush-sdk/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/eslint/eslint-config/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/heft-plugins/heft-lint-plugin/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/heft-plugins/heft-typescript-plugin/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/libraries/heft-config-file/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/libraries/lookup-by-path/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/libraries/node-core-library/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/libraries/package-deps-hash/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/libraries/package-extractor/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/libraries/rig-package/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/libraries/stream-collator/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/libraries/ts-command-line/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/libraries/operation-graph/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/apps/api-extractor/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/rigs/heft-node-rig/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/eslint/local-eslint-config/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/eslint/eslint-patch/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/eslint/eslint-plugin/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/eslint/eslint-plugin-packlets/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/eslint/eslint-plugin-security/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/libraries/api-extractor-model/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/heft-plugins/heft-api-extractor-plugin/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/heft-plugins/heft-jest-plugin/node_modules/.pnpm-sync.json
pnpm-sync: Writing /Users/ianc/code/rushstack2/libraries/tree-pattern/node_modules/.pnpm-sync.json
pnpm-sync: Regenerated .pnpm-sync.json in 22 ms

Installing for subspace: default
Checking Git policy for this repository.


Found files in the "common/git-hooks" folder.
Successfully installed these Git hook scripts: pre-commit

Trying to acquire lock for pnpm-9.15.9
Acquired lock for pnpm-9.15.9
Found pnpm version 9.15.9 in /Users/ianc/.rush/node-v22.12.0/pnpm-9.15.9

Symlinking "/Users/ianc/code/rushstack2/common/temp/pnpm-local"
  --> "/Users/ianc/.rush/node-v22.12.0/pnpm-9.15.9"
Transforming /Users/ianc/code/rushstack2/common/config/subspaces/default/.npmrc
  --> "/Users/ianc/code/rushstack2/common/temp/default/.npmrc"

Updating workspace files in /Users/ianc/code/rushstack2/common/temp/default
Total amount of time spent to hash related package.json files in the injected installation case: 0.00 seconds
Copying "/Users/ianc/code/rushstack2/common/config/subspaces/default/pnpm-lock.yaml"
  --> "/Users/ianc/code/rushstack2/common/temp/default/pnpm-lock.yaml"
Copying "/Users/ianc/code/rushstack2/common/config/subspaces/default/pnpm-lock.yaml"
  --> "/Users/ianc/code/rushstack2/common/temp/default/pnpm-lock-preinstall.yaml"

Checking installation in "/Users/ianc/code/rushstack2/common/temp/default"

Skipping package registry setup because packageRegistry.enabled=falseDeleting files from /Users/ianc/code/rushstack2/common/temp/default/node_modules

Running "pnpm install" in /Users/ianc/code/rushstack2/common/temp/default


Invoking package manager: /Users/ianc/.rush/node-v22.12.0/pnpm-9.15.9/node_modules/pnpm/bin/pnpm.cjs install --store /Users/ianc/code/rushstack2/common/temp/pnpm-store --config.cacheDir=/Users/ianc/code/rushstack2/common/temp/pnpm-store --config.stateDir=/Users/ianc/code/rushstack2/common/temp/pnpm-store --prefer-frozen-lockfile --strict-peer-dependencies --config.auto-install-peers=false --config.resolutionMode=highest --config.ignoreCompatibilityDb --recursive --link-workspace-packages false --reporter default

Scope: all 154 workspace projects
.../heft-node-basic-tutorial             |  WARN  deprecated eslint@8.57.0
../../../libraries/rush-lib              |  WARN  deprecated read-package-tree@5.1.6
.../rush-vscode-extension                |  WARN  deprecated vsce@2.14.0
 WARN  40 deprecated subdependencies found: @aws-cdk/aws-apigatewayv2-alpha@2.50.0-alpha.0, @aws-cdk/aws-apigatewayv2-authorizers-alpha@2.50.0-alpha.0, @aws-cdk/aws-apigatewayv2-integrations-alpha@2.50.0-alpha.0, @babel/plugin-proposal-class-properties@7.18.6, @babel/plugin-proposal-nullish-coalescing-operator@7.18.6, @babel/plugin-proposal-object-rest-spread@7.12.1, @babel/plugin-proposal-object-rest-spread@7.20.7, @babel/plugin-proposal-optional-chaining@7.21.0, @babel/plugin-proposal-private-methods@7.18.6, @fluentui/react-infobutton@9.0.0-beta.47, @humanwhocodes/config-array@0.10.7, @humanwhocodes/config-array@0.11.14, @humanwhocodes/config-array@0.9.5, @humanwhocodes/object-schema@1.2.1, @humanwhocodes/object-schema@2.0.2, @npmcli/move-file@1.1.2, abab@2.0.6, chokidar@2.1.8, debuglog@1.0.1, domexception@4.0.0, fastify-warning@0.2.0, figgy-pudding@3.5.2, fsevents@1.2.13, fsevents@2.1.3, querystring@0.2.0, readdir-scoped-modules@1.1.0, resolve-url@0.2.1, rimraf@2.6.3, rimraf@2.7.1, rimraf@3.0.2, sane@4.1.0, source-map-resolve@0.5.3, source-map-url@0.4.1, stable@0.1.8, string-similarity@4.0.4, trim@0.0.1, urix@0.1.0, uuid-browser@3.1.0, uuid@3.4.0, z-schema@5.0.6
.                                        |    +2729 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 2734, reused 2664, downloaded 0, added 2729, done

The command failed:
 /Users/ianc/code/rushstack2/common/temp/pnpm-local/node_modules/.bin/pnpm install --store /Users/ianc/code/rushstack2/common/temp/pnpm-store --config.cacheDir=/Users/ianc/code/rushstack2/common/temp/pnpm-store --config.stateDir=/Users/ianc/code/rushstack2/common/temp/pnpm-store --prefer-frozen-lockfile --strict-peer-dependencies --config.auto-install-peers=false --config.resolutionMode=highest --config.ignoreCompatibilityDb --recursive --link-workspace-packages false --reporter default
ERROR: Error: Process exited with code 1
Giving up after 1 attempts


ERROR: Process exited with code 1

Error: Process exited with code 1
    at ChildProcess.<anonymous> (/Users/ianc/code/rushstack5/libraries/node-core-library/lib/Executable.js:331:28)
    at ChildProcess.emit (node:events:524:28)
    at maybeClose (node:internal/child_process:1101:16)
    at ChildProcess._handle.onexit (node:internal/child_process:304:5)
```